### PR TITLE
Add migration tag to rules and export some more native symbols

### DIFF
--- a/proto/README.md
+++ b/proto/README.md
@@ -1,0 +1,6 @@
+Unless explicitly stated otherwise, everything in this folder and all subfolders
+is considered to be an implementation detail and may change at any time without
+prior notice.
+
+Exceptions from this rule:
+  - All symbols exported in `//proto:defs.bzl` and `//proto:repositories.bzl`.

--- a/proto/defs.bzl
+++ b/proto/defs.bzl
@@ -12,6 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("//proto/private:native.bzl", "NativeProtoInfo", "native_proto_common")
+
+_MIGRATION_TAG = "__PROTO_RULES_MIGRATION_DO_NOT_USE_WILL_BREAK__"
+
+def _add_migration_tag(attrs):
+    if "tags" in attrs and attrs["tags"] != None:
+        attrs["tags"] += [_MIGRATION_TAG]
+    else:
+        attrs["tags"] = [_MIGRATION_TAG]
+    return attrs
+
 def proto_lang_toolchain(**attrs):
     """Bazel proto_lang_toolchain rule.
 
@@ -20,7 +31,7 @@ def proto_lang_toolchain(**attrs):
     Args:
       **attrs: Rule attributes
     """
-    native.proto_lang_toolchain(**attrs)
+    native.proto_lang_toolchain(**_add_migration_tag(attrs))
 
 def proto_library(**attrs):
     """Bazel proto_library rule.
@@ -30,4 +41,16 @@ def proto_library(**attrs):
     Args:
       **attrs: Rule attributes
     """
-    native.proto_library(**attrs)
+    native.proto_library(**_add_migration_tag(attrs))
+
+ProtoInfo = NativeProtoInfo
+"""Encapsulates information provided by `proto_library`.
+
+https://docs.bazel.build/versions/master/skylark/lib/ProtoInfo.html
+"""
+
+proto_common = native_proto_common
+"""Utilities for protocol buffers.
+
+https://docs.bazel.build/versions/master/skylark/lib/proto_common.html
+"""

--- a/proto/private/BUILD
+++ b/proto/private/BUILD
@@ -1,0 +1,1 @@
+# Intentionally left empty (for now).

--- a/proto/private/dependencies.bzl
+++ b/proto/private/dependencies.bzl
@@ -1,0 +1,38 @@
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+dependencies = {
+    "bazel_skylib": {
+        "sha256": "2ef429f5d7ce7111263289644d233707dba35e39696377ebab8b0bc701f7818e",
+        "urls": [
+            "https://github.com/bazelbuild/bazel-skylib/archive/0.8.0.tar.gz",
+        ],
+    },
+    "com_google_protobuf": {
+        "sha256": "2ee9dcec820352671eb83e081295ba43f7a4157181dad549024d7070d079cf65",
+        "strip_prefix": "protobuf-3.9.0",
+        "urls": [
+            "https://mirror.bazel.build/github.com/google/protobuf/archive/v3.9.0.tar.gz",
+            "https://github.com/protocolbuffers/protobuf/archive/v3.9.0.tar.gz",
+        ],
+    },
+    "zlib": {
+        "sha256": "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
+        "build_file": "@com_google_protobuf//:third_party/zlib.BUILD",
+        "strip_prefix": "zlib-1.2.11",
+        "urls": [
+            "https://zlib.net/zlib-1.2.11.tar.gz",
+        ],
+    },
+}

--- a/proto/private/native.bzl
+++ b/proto/private/native.bzl
@@ -12,19 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//proto/private:dependencies.bzl", "dependencies")
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+# Redefine native symbols with a new name as a workaround for
+# exporting them in `//proto:defs.bzl` with their original name.
+#
+# While we cannot force users to load these symbol due to the lack of a
+# whitelisting mechanism, we can still export them and tell users to
+# load it to make a future migration to pure Starlark easier.
 
-def rules_proto_dependencies():
-    for name in dependencies:
-        if name in native.existing_rules():
-            continue
+NativeProtoInfo = ProtoInfo
 
-        http_archive(
-            name = name,
-            **dependencies[name]
-        )
-
-def rules_proto_toolchains():
-    # Nothing to do here (yet).
-    pass
+native_proto_common = proto_common

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -1,0 +1,8 @@
+load("//proto:defs.bzl", "proto_library")
+
+proto_library(
+    name = "empty_proto",
+    srcs = [
+        "empty.proto",
+    ],
+)

--- a/tests/empty.proto
+++ b/tests/empty.proto
@@ -1,0 +1,17 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package rules_proto.tests;


### PR DESCRIPTION
This change is in preparation for `--incompatible_load_proto_rules_from_bzl`.

See https://github.com/bazelbuild/bazel/issues/8891

@hlopko ptal