### PR TITLE
Add CODEOWNERS for rules_proto

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @hlopko @laurentlb @lberki
+* @dbabkin @hlopko @lberki

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @hlopko @laurentlb @lberki


### PR DESCRIPTION
Initial list of owners derived from https://docs.google.com/document/d/1Wai_okIK_NnhNJZai5nkTUvZVHdV5pp1YwNLFtWwpC4/edit?disco=AAAADI3o84E