### PR TITLE
fix(docs): update source archive from `.tar.gz` to `.zip`

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ http_archive(
     sha256 = "602e7161d9195e50246177e7c55b2f39950a9cf7366f74ed5f22fd45750cd208",
     strip_prefix = "rules_proto-97d8af4dc474595af3900dd85cb3a29ad28cc313",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_proto/archive/97d8af4dc474595af3900dd85cb3a29ad28cc313.tar.gz",
-        "https://github.com/bazelbuild/rules_proto/archive/97d8af4dc474595af3900dd85cb3a29ad28cc313.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_proto/archive/97d8af4dc474595af3900dd85cb3a29ad28cc313.zip",
+        "https://github.com/bazelbuild/rules_proto/archive/97d8af4dc474595af3900dd85cb3a29ad28cc313.zip",
     ],
 )
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")


### PR DESCRIPTION
The README incorrectly lists the archive format of the `urls` property
as `.tar.gz`, when in fact both sources are `.zip`. This patch simply
updates the README to avoid confusing users who expect that the
installation instructions can be copied and pasted.

---

I can update the SHA256 as well, if you would like.