### PR TITLE
Use released protoc binaries

### DIFF
--- a/proto/private/BUILD.protoc
+++ b/proto/private/BUILD.protoc
@@ -1,5 +1,8 @@
-alias(
+load("@rules_proto//proto/private:dependencies.bzl", "protoc_binary")
+
+protoc_binary(
     name = "protoc",
-    actual = "bin/protoc",
+    src = "bin/protoc",
+    executable = "protoc_bin",
     visibility = ["//visibility:public"],
 )

--- a/proto/private/BUILD.protoc
+++ b/proto/private/BUILD.protoc
@@ -1,0 +1,5 @@
+alias(
+    name = "protoc",
+    actual = "bin/protoc",
+    visibility = ["//visibility:public"],
+)

--- a/proto/private/BUILD.protoc
+++ b/proto/private/BUILD.protoc
@@ -4,9 +4,9 @@ protoc_binary(
     name = "protoc",
     srcs = select({
         ":windows": ["bin/protoc.exe"],
-        "//conditions:default": ["bin/protoc"]
+        "//conditions:default": ["bin/protoc"],
     }),
-    executable = "protoc_bin",
+    executable = "protoc.exe",
     visibility = ["//visibility:public"],
 )
 

--- a/proto/private/BUILD.protoc
+++ b/proto/private/BUILD.protoc
@@ -2,7 +2,17 @@ load("@rules_proto//proto/private:dependencies.bzl", "protoc_binary")
 
 protoc_binary(
     name = "protoc",
-    src = "bin/protoc",
+    srcs = select({
+        ":windows": ["bin/protoc.exe"],
+        "//conditions:default": ["bin/protoc"]
+    }),
     executable = "protoc_bin",
     visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "windows",
+    constraint_values = [
+        "@platforms//os:windows",
+    ],
 )

--- a/proto/private/BUILD.protoc_windows
+++ b/proto/private/BUILD.protoc_windows
@@ -1,5 +1,8 @@
-alias(
+load("@rules_proto//proto/private:dependencies.bzl", "protoc_binary")
+
+protoc_binary(
     name = "protoc",
-    actual = "bin/protoc.exe",
+    src = "bin/protoc.exe",
+    executable = "protoc.exe",
     visibility = ["//visibility:public"],
 )

--- a/proto/private/BUILD.protoc_windows
+++ b/proto/private/BUILD.protoc_windows
@@ -1,0 +1,5 @@
+alias(
+    name = "protoc",
+    actual = "bin/protoc.exe",
+    visibility = ["//visibility:public"],
+)

--- a/proto/private/BUILD.protoc_windows
+++ b/proto/private/BUILD.protoc_windows
@@ -1,8 +1,0 @@
-load("@rules_proto//proto/private:dependencies.bzl", "protoc_binary")
-
-protoc_binary(
-    name = "protoc",
-    src = "bin/protoc.exe",
-    executable = "protoc.exe",
-    visibility = ["//visibility:public"],
-)

--- a/proto/private/BUILD.release
+++ b/proto/private/BUILD.release
@@ -24,6 +24,12 @@ alias(
 )
 
 alias(
+    name = "protobuf_java_util",
+    actual = "@com_google_protobuf_protobuf_java_util//jar",
+    visibility = ["//visibility:public"],
+)
+
+alias(
     name = "protobuf_javalite",
     actual = "@com_google_protobuf_protobuf_javalite//jar",
     visibility = ["//visibility:public"],
@@ -71,8 +77,6 @@ redirect_targets = [
     "any_proto",
     "protoc_lib",
     "protobuf",
-    "protobuf_lite",
-    "protobuf_java_util",
 ]
 
 [

--- a/proto/private/BUILD.release
+++ b/proto/private/BUILD.release
@@ -1,0 +1,276 @@
+# Use precompiled binaries where possible.
+alias(
+    name = "protoc",
+    actual = select({
+        "//conditions:default": "@com_github_protocolbuffers_protobuf//:protoc",
+        ":linux-aarch64": "@com_google_protobuf_protoc_linux_aarch64//:protoc",
+        ":linux-ppc": "@com_google_protobuf_protoc_linux_ppc//:protoc",
+        ":linux-s390x": "@com_google_protobuf_protoc_linux_s390x//:protoc",
+        ":linux-x86_32": "@com_google_protobuf_protoc_linux_x86_32//:protoc",
+        ":linux-x86_64": "@com_google_protobuf_protoc_linux_x86_64//:protoc",
+        ":macos-x86_32": "@com_google_protobuf_protoc_macos_x86_32//:protoc",
+        ":macos-x86_64": "@com_google_protobuf_protoc_macos_x86_64//:protoc",
+        ":windows-x86_32": "@com_google_protobuf_protoc_windows_x86_32//:protoc",
+        ":windows-x86_64": "@com_google_protobuf_protoc_windows_x86_64//:protoc",
+    }),
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "protobuf_java",
+    actual = "@com_google_protobuf_protobuf_java//jar",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "protobuf_javalite",
+    actual = "@com_google_protobuf_protobuf_javalite//jar",
+    visibility = ["//visibility:public"],
+)
+
+# Redirect everything else to the source
+alias(
+    name = "wrappers_proto",
+    actual = "@com_github_protocolbuffers_protobuf//:wrappers_proto",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "well_known_protos",
+    actual = "@com_github_protocolbuffers_protobuf//:well_known_protos",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "timestamp_proto",
+    actual = "@com_github_protocolbuffers_protobuf//:timestamp_proto",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "struct_proto",
+    actual = "@com_github_protocolbuffers_protobuf//:struct_proto",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "python_specific_test_protos_genproto",
+    actual = "@com_github_protocolbuffers_protobuf//:python_specific_test_protos_genproto",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "python_common_test_protos_genproto",
+    actual = "@com_github_protocolbuffers_protobuf//:python_common_test_protos_genproto",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "protobuf_python_genproto",
+    actual = "@com_github_protocolbuffers_protobuf//:protobuf_python_genproto",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "protobuf_python",
+    actual = "@com_github_protocolbuffers_protobuf//:protobuf_python",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "protobuf_objc",
+    actual = "@com_github_protocolbuffers_protobuf//:protobuf_objc",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "protobuf_headers",
+    actual = "@com_github_protocolbuffers_protobuf//:protobuf_headers",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "objectivec",
+    actual = "@com_github_protocolbuffers_protobuf//:objectivec",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "java_toolchain",
+    actual = "@com_github_protocolbuffers_protobuf//:java_toolchain",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "field_mask_proto",
+    actual = "@com_github_protocolbuffers_protobuf//:field_mask_proto",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "empty_proto",
+    actual = "@com_github_protocolbuffers_protobuf//:empty_proto",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "duration_proto",
+    actual = "@com_github_protocolbuffers_protobuf//:duration_proto",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "compiler_plugin_proto",
+    actual = "@com_github_protocolbuffers_protobuf//:compiler_plugin_proto",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "descriptor_proto",
+    actual = "@com_github_protocolbuffers_protobuf//:descriptor_proto",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "cc_wkt_protos",
+    actual = "@com_github_protocolbuffers_protobuf//:cc_wkt_protos",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "cc_toolchain",
+    actual = "@com_github_protocolbuffers_protobuf//:cc_toolchain",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "cc_test_protos_genproto",
+    actual = "@com_github_protocolbuffers_protobuf//:cc_test_protos_genproto",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "cc_wkt_protos_genproto",
+    actual = "@com_github_protocolbuffers_protobuf//:cc_wkt_protos_genproto",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "api_proto",
+    actual = "@com_github_protocolbuffers_protobuf//:api_proto",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "type_proto",
+    actual = "@com_github_protocolbuffers_protobuf//:type_proto",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "source_context_proto",
+    actual = "@com_github_protocolbuffers_protobuf//:source_context_proto",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "any_proto",
+    actual = "@com_github_protocolbuffers_protobuf//:any_proto",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "protoc_lib",
+    actual = "@com_github_protocolbuffers_protobuf//:protoc_lib",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "protobuf",
+    actual = "@com_github_protocolbuffers_protobuf//:protobuf",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "protobuf_lite",
+    actual = "@com_github_protocolbuffers_protobuf//:protobuf_lite",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "protobuf_java_util",
+    actual = "@com_github_protocolbuffers_protobuf//:protobuf_java_util",
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "linux-aarch64",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:aarch64",
+    ],
+)
+
+config_setting(
+    name = "linux-ppc",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:ppc",
+    ],
+)
+
+config_setting(
+    name = "linux-s390x",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:s390x",
+    ],
+)
+
+config_setting(
+    name = "linux-x86_32",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_32",
+    ],
+)
+
+config_setting(
+    name = "linux-x86_64",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+)
+
+config_setting(
+    name = "macos-x86_32",
+    constraint_values = [
+        "@platforms//os:osx",
+        "@platforms//cpu:x86_32",
+    ],
+)
+
+config_setting(
+    name = "macos-x86_64",
+    constraint_values = [
+        "@platforms//os:osx",
+        "@platforms//cpu:x86_64",
+    ],
+)
+
+config_setting(
+    name = "windows-x86_32",
+    constraint_values = [
+        "@platforms//os:windows",
+        "@platforms//cpu:x86_32",
+    ],
+)
+
+config_setting(
+    name = "windows-x86_64",
+    constraint_values = [
+        "@platforms//os:windows",
+        "@platforms//cpu:x86_64",
+    ],
+)

--- a/proto/private/BUILD.release
+++ b/proto/private/BUILD.release
@@ -2,7 +2,6 @@
 alias(
     name = "protoc",
     actual = select({
-        "//conditions:default": "@com_github_protocolbuffers_protobuf//:protoc",
         ":linux-aarch64": "@com_google_protobuf_protoc_linux_aarch64//:protoc",
         ":linux-ppc": "@com_google_protobuf_protoc_linux_ppc//:protoc",
         ":linux-s390x": "@com_google_protobuf_protoc_linux_s390x//:protoc",
@@ -12,10 +11,12 @@ alias(
         ":macos-x86_64": "@com_google_protobuf_protoc_macos_x86_64//:protoc",
         ":windows-x86_32": "@com_google_protobuf_protoc_windows_x86_32//:protoc",
         ":windows-x86_64": "@com_google_protobuf_protoc_windows_x86_64//:protoc",
+        "//conditions:default": "@com_github_protocolbuffers_protobuf//:protoc",
     }),
     visibility = ["//visibility:public"],
 )
 
+# Use the jars from maven.
 alias(
     name = "protobuf_java",
     actual = "@com_google_protobuf_protobuf_java//jar",
@@ -28,180 +29,60 @@ alias(
     visibility = ["//visibility:public"],
 )
 
-# Redirect everything else to the source
-alias(
-    name = "wrappers_proto",
-    actual = "@com_github_protocolbuffers_protobuf//:wrappers_proto",
-    visibility = ["//visibility:public"],
-)
-
-alias(
-    name = "well_known_protos",
-    actual = "@com_github_protocolbuffers_protobuf//:well_known_protos",
-    visibility = ["//visibility:public"],
-)
-
-alias(
-    name = "timestamp_proto",
-    actual = "@com_github_protocolbuffers_protobuf//:timestamp_proto",
-    visibility = ["//visibility:public"],
-)
-
-alias(
-    name = "struct_proto",
-    actual = "@com_github_protocolbuffers_protobuf//:struct_proto",
-    visibility = ["//visibility:public"],
-)
-
-alias(
-    name = "python_specific_test_protos_genproto",
-    actual = "@com_github_protocolbuffers_protobuf//:python_specific_test_protos_genproto",
-    visibility = ["//visibility:public"],
-)
-
-alias(
-    name = "python_common_test_protos_genproto",
-    actual = "@com_github_protocolbuffers_protobuf//:python_common_test_protos_genproto",
-    visibility = ["//visibility:public"],
-)
-
-alias(
-    name = "protobuf_python_genproto",
-    actual = "@com_github_protocolbuffers_protobuf//:protobuf_python_genproto",
-    visibility = ["//visibility:public"],
-)
-
-alias(
-    name = "protobuf_python",
-    actual = "@com_github_protocolbuffers_protobuf//:protobuf_python",
-    visibility = ["//visibility:public"],
-)
-
-alias(
-    name = "protobuf_objc",
-    actual = "@com_github_protocolbuffers_protobuf//:protobuf_objc",
-    visibility = ["//visibility:public"],
-)
-
-alias(
-    name = "protobuf_headers",
-    actual = "@com_github_protocolbuffers_protobuf//:protobuf_headers",
-    visibility = ["//visibility:public"],
-)
-
-alias(
-    name = "objectivec",
-    actual = "@com_github_protocolbuffers_protobuf//:objectivec",
-    visibility = ["//visibility:public"],
-)
-
-alias(
+proto_lang_toolchain(
     name = "java_toolchain",
-    actual = "@com_github_protocolbuffers_protobuf//:java_toolchain",
+    command_line = "--java_out=$(OUT)",
+    runtime = ":protobuf_java",
     visibility = ["//visibility:public"],
 )
 
-alias(
-    name = "field_mask_proto",
-    actual = "@com_github_protocolbuffers_protobuf//:field_mask_proto",
+proto_lang_toolchain(
+    name = "javalite_toolchain",
+    command_line = "--java_out=lite:$(OUT)",
+    runtime = ":protobuf_javalite",
     visibility = ["//visibility:public"],
 )
 
-alias(
-    name = "empty_proto",
-    actual = "@com_github_protocolbuffers_protobuf//:empty_proto",
-    visibility = ["//visibility:public"],
-)
+# Redirect everything else to the source
+redirect_targets = [
+    "wrappers_proto",
+    "well_known_protos",
+    "timestamp_proto",
+    "struct_proto",
+    "python_specific_test_protos_genproto",
+    "python_common_test_protos_genproto",
+    "protobuf_python_genproto",
+    "protobuf_python",
+    "protobuf_objc",
+    "protobuf_headers",
+    "objectivec",
+    "field_mask_proto",
+    "empty_proto",
+    "duration_proto",
+    "compiler_plugin_proto",
+    "descriptor_proto",
+    "cc_wkt_protos",
+    "cc_toolchain",
+    "cc_test_protos_genproto",
+    "cc_wkt_protos_genproto",
+    "api_proto",
+    "type_proto",
+    "source_context_proto",
+    "any_proto",
+    "protoc_lib",
+    "protobuf",
+    "protobuf_lite",
+    "protobuf_java_util",
+]
 
-alias(
-    name = "duration_proto",
-    actual = "@com_github_protocolbuffers_protobuf//:duration_proto",
-    visibility = ["//visibility:public"],
-)
-
-alias(
-    name = "compiler_plugin_proto",
-    actual = "@com_github_protocolbuffers_protobuf//:compiler_plugin_proto",
-    visibility = ["//visibility:public"],
-)
-
-alias(
-    name = "descriptor_proto",
-    actual = "@com_github_protocolbuffers_protobuf//:descriptor_proto",
-    visibility = ["//visibility:public"],
-)
-
-alias(
-    name = "cc_wkt_protos",
-    actual = "@com_github_protocolbuffers_protobuf//:cc_wkt_protos",
-    visibility = ["//visibility:public"],
-)
-
-alias(
-    name = "cc_toolchain",
-    actual = "@com_github_protocolbuffers_protobuf//:cc_toolchain",
-    visibility = ["//visibility:public"],
-)
-
-alias(
-    name = "cc_test_protos_genproto",
-    actual = "@com_github_protocolbuffers_protobuf//:cc_test_protos_genproto",
-    visibility = ["//visibility:public"],
-)
-
-alias(
-    name = "cc_wkt_protos_genproto",
-    actual = "@com_github_protocolbuffers_protobuf//:cc_wkt_protos_genproto",
-    visibility = ["//visibility:public"],
-)
-
-alias(
-    name = "api_proto",
-    actual = "@com_github_protocolbuffers_protobuf//:api_proto",
-    visibility = ["//visibility:public"],
-)
-
-alias(
-    name = "type_proto",
-    actual = "@com_github_protocolbuffers_protobuf//:type_proto",
-    visibility = ["//visibility:public"],
-)
-
-alias(
-    name = "source_context_proto",
-    actual = "@com_github_protocolbuffers_protobuf//:source_context_proto",
-    visibility = ["//visibility:public"],
-)
-
-alias(
-    name = "any_proto",
-    actual = "@com_github_protocolbuffers_protobuf//:any_proto",
-    visibility = ["//visibility:public"],
-)
-
-alias(
-    name = "protoc_lib",
-    actual = "@com_github_protocolbuffers_protobuf//:protoc_lib",
-    visibility = ["//visibility:public"],
-)
-
-alias(
-    name = "protobuf",
-    actual = "@com_github_protocolbuffers_protobuf//:protobuf",
-    visibility = ["//visibility:public"],
-)
-
-alias(
-    name = "protobuf_lite",
-    actual = "@com_github_protocolbuffers_protobuf//:protobuf_lite",
-    visibility = ["//visibility:public"],
-)
-
-alias(
-    name = "protobuf_java_util",
-    actual = "@com_github_protocolbuffers_protobuf//:protobuf_java_util",
-    visibility = ["//visibility:public"],
-)
+[
+    alias(
+        name = target,
+        actual = "@com_github_protocolbuffers_protobuf//:" + target,
+        visibility = ["//visibility:public"],
+    )
+    for target in redirect_targets
+]
 
 config_setting(
     name = "linux-aarch64",

--- a/proto/private/BUILD.release
+++ b/proto/private/BUILD.release
@@ -1,3 +1,5 @@
+load("@rules_proto//proto:defs.bzl", "proto_lang_toolchain")
+
 # Use precompiled binaries where possible.
 alias(
     name = "protoc",

--- a/proto/private/dependencies.bzl
+++ b/proto/private/dependencies.bzl
@@ -80,7 +80,7 @@ dependencies = {
     },
     "com_google_protobuf_protoc_windows_x86_64": {
         "build_file": "@rules_proto//proto/private:BUILD.protoc_windows",
-        "sha256": "eca7c20ad11ae31abffee1f593dc5a0b2e3b97e5eff275125413d196a7513090",
+        "sha256": "1490944d3bbf77b58bcbd175fef6fbf14cc9c20f79be06c4be827641af1c6ca2",
         "urls": [
             "https://github.com/protocolbuffers/protobuf/releases/download/v3.11.3/protoc-3.11.3-win64.zip",
         ],

--- a/proto/private/dependencies.bzl
+++ b/proto/private/dependencies.bzl
@@ -165,8 +165,8 @@ protobuf_workspace = repository_rule(
     implementation = _protobuf_workspace_impl,
     attrs = {
         "_build": attr.label(default = "@rules_proto//proto/private:BUILD.release"),
-        "_protobuf_bzl": attr.label(default="@com_github_protocolbuffers_protobuf//:protobuf.bzl"),
-        "_protobuf_deps_bzl": attr.label(default="@com_github_protocolbuffers_protobuf//:protobuf.bzl"),
+        "_protobuf_bzl": attr.label(default = "@com_github_protocolbuffers_protobuf//:protobuf.bzl"),
+        "_protobuf_deps_bzl": attr.label(default = "@com_github_protocolbuffers_protobuf//:protobuf.bzl"),
     },
 )
 
@@ -178,5 +178,5 @@ def protoc_binary(name, src, executable, **kwargs):
         outs = [executable],
         cmd_bash = "cp $< $@&&chmod +x $@",
         cmd_bat = "copy $< $@",
-        **kwargs,
+        **kwargs
     )

--- a/proto/private/dependencies.bzl
+++ b/proto/private/dependencies.bzl
@@ -24,7 +24,7 @@ dependencies = {
     },
     "com_google_protobuf_protoc_linux_aarch64": {
         "build_file": "@rules_proto//proto/private:BUILD.protoc",
-        "sha256": "45276570e524c50f6ce82ed71ba87c75f0c8c69ca89adbf86ce0000049df27e5",        
+        "sha256": "45276570e524c50f6ce82ed71ba87c75f0c8c69ca89adbf86ce0000049df27e5",
         "urls": [
             "https://github.com/protocolbuffers/protobuf/releases/download/v3.10.0/protoc-3.10.0-linux-aarch_64.zip",
         ],
@@ -140,16 +140,16 @@ dependencies = {
 }
 
 maven_dependencies = {
-    "com_google_protobuf_protobuf_java":{
+    "com_google_protobuf_protobuf_java": {
         "artifact": "com.google.protobuf:protobuf-java:3.10.0",
         "sha1": "410b61dd0088aab4caa05739558d43df248958c9",
         "sha1_src": "3ee94b1a2c1a74d9a27196e39c4bcf8dd0101e70",
     },
-    "com_google_protobuf_protobuf_javalite":{
+    "com_google_protobuf_protobuf_javalite": {
         "artifact": "com.google.protobuf:protobuf-javalite:3.10.0",
-        "sha1":"a7e0350493910f45a208732992f8e519ade2fde5",
+        "sha1": "a7e0350493910f45a208732992f8e519ade2fde5",
         "sha1_src": "e43e8517029380185acc014f5dc6ee2ade484fb1",
-    }
+    },
 }
 
 def _protobuf_workspace_impl(ctx):
@@ -158,6 +158,30 @@ def _protobuf_workspace_impl(ctx):
 protobuf_workspace = repository_rule(
     implementation = _protobuf_workspace_impl,
     attrs = {
-        "_build": attr.label(default="@rules_proto//proto/private:BUILD.release")
-    }
+        "_build": attr.label(default = "@rules_proto//proto/private:BUILD.release"),
+    },
+)
+
+def _protoc_binary_impl(ctx):
+    args = ctx.actions.args()
+    args.add(ctx.file.src)
+    args.add(ctx.outputs.executable)
+    ctx.actions.run_shell(
+        inputs = [ctx.file.src],
+        outputs = [ctx.outputs.executable],
+        command = "cp $1 $2&&chmod +x $2",
+        arguments = [args],
+    )
+    return [DefaultInfo(executable = ctx.outputs.executable)]
+
+protoc_binary = rule(
+    implementation = _protoc_binary_impl,
+    attrs = {
+        "src": attr.label(
+            allow_single_file = True,
+            executable = True,
+            cfg = "target",
+        ),
+        "executable": attr.output(mandatory = True),
+    },
 )

--- a/proto/private/dependencies.bzl
+++ b/proto/private/dependencies.bzl
@@ -143,16 +143,16 @@ maven_dependencies = {
     "com_google_protobuf_protobuf_java": {
         "jar_sha256": "4e567f364f5608606616ef764e801d66a52e5241577ad7405f519a3a8a6802bb",
         "jar_urls": ["https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java/3.11.3/protobuf-java-3.11.3.jar"],
+        "licenses": ["notice"],
         "srcjar_sha256": "9d2ee817e71c63f197271d425b11dac1414926302eea1d2eaae5e4fd2ca31d5d",
         "srcjar_urls": ["https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java/3.11.3/protobuf-java-3.11.3-sources.jar"],
-        "licenses": ["notice"],
     },
     "com_google_protobuf_protobuf_javalite": {
         "jar_sha256": "5ff32ba40ce12b859898600a967a69094ae38bb57f619cf08c2160ae376174b6",
         "jar_urls": ["https://repo1.maven.org/maven2/com/google/protobuf/protobuf-javalite/3.11.3/protobuf-javalite-3.11.3.jar"],
+        "licenses": ["notice"],
         "srcjar_sha256": "6eeb3fa7f7bae8b41847cf49858454b1dd1a6859f0cfe50ffb6f846c5e027d49",
         "srcjar_urls": ["https://repo1.maven.org/maven2/com/google/protobuf/protobuf-javalite/3.11.3/protobuf-javalite-3.11.3-sources.jar"],
-        "licenses": ["notice"],
     },
 }
 

--- a/proto/private/dependencies.bzl
+++ b/proto/private/dependencies.bzl
@@ -26,8 +26,8 @@ dependencies = {
         "sha256": "cf754718b0aa945b00550ed7962ddc167167bd922b842199eeb6505e6f344852",
         "strip_prefix": "protobuf-3.11.3",
         "urls": [
-            "https://mirror.bazel.build/mirror.bazel.build/github.com/protocolbuffers/protobuf/archive/v3.11.3.tar.gz",
             "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/archive/v3.11.3.tar.gz",
+            "https://github.com/protocolbuffers/protobuf/archive/v3.11.3.tar.gz",
         ],
     },
     "com_google_protobuf_protoc_linux_aarch64": {
@@ -211,6 +211,7 @@ def protoc_binary(name, srcs, executable, **kwargs):
 
 This is a workaround to make sure protoc can be used with attributes
 which don't allow files."""
+
     # TODO(yannic) replace this with a symlink after https://github.com/bazelbuild/bazel/pull/10695
     native.genrule(
         name = name,

--- a/proto/private/dependencies.bzl
+++ b/proto/private/dependencies.bzl
@@ -26,14 +26,15 @@ dependencies = {
         "sha256": "cf754718b0aa945b00550ed7962ddc167167bd922b842199eeb6505e6f344852",
         "strip_prefix": "protobuf-3.11.3",
         "urls": [
+            "https://mirror.bazel.build/mirror.bazel.build/github.com/protocolbuffers/protobuf/archive/v3.11.3.tar.gz",
             "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/archive/v3.11.3.tar.gz",
-            "https://github.com/protocolbuffers/protobuf/archive/v3.11.3.tar.gz",
         ],
     },
     "com_google_protobuf_protoc_linux_aarch64": {
         "build_file": "@rules_proto//proto/private:BUILD.protoc",
         "sha256": "3994233e61c287a377a9134e658ca3034924849f0e3a82d12b0e6efa2bed4b46",
         "urls": [
+            "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/releases/download/v3.11.3/protoc-3.11.3-linux-aarch_64.zip",
             "https://github.com/protocolbuffers/protobuf/releases/download/v3.11.3/protoc-3.11.3-linux-aarch_64.zip",
         ],
     },
@@ -41,6 +42,7 @@ dependencies = {
         "build_file": "@rules_proto//proto/private:BUILD.protoc",
         "sha256": "0dc5bf7eea3ee742ea7f56f51a229dac18e2deef330d5ccaef75c6d629469be7",
         "urls": [
+            "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/releases/download/v3.11.3/protoc-3.11.3-linux-ppcle_64.zip",
             "https://github.com/protocolbuffers/protobuf/releases/download/v3.11.3/protoc-3.11.3-linux-ppcle_64.zip",
         ],
     },
@@ -48,6 +50,7 @@ dependencies = {
         "build_file": "@rules_proto//proto/private:BUILD.protoc",
         "sha256": "81d8647b168af8f2cb3b1c2a665e35648a2c2906f3cb59382f39c7842ae639e3",
         "urls": [
+            "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/releases/download/v3.11.3/protoc-3.11.3-linux-s390x_64.zip",
             "https://github.com/protocolbuffers/protobuf/releases/download/v3.11.3/protoc-3.11.3-linux-s390x_64.zip",
         ],
     },
@@ -55,6 +58,7 @@ dependencies = {
         "build_file": "@rules_proto//proto/private:BUILD.protoc",
         "sha256": "840d0f8ef9886707b12414de4c100f62e6a5135b533040d3117e4b80db09e8ac",
         "urls": [
+            "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/releases/download/v3.11.3/protoc-3.11.3-linux-x86_32.zip",
             "https://github.com/protocolbuffers/protobuf/releases/download/v3.11.3/protoc-3.11.3-linux-x86_32.zip",
         ],
     },
@@ -62,6 +66,7 @@ dependencies = {
         "build_file": "@rules_proto//proto/private:BUILD.protoc",
         "sha256": "39f5d64b0f31117c94651c880d0a776159e49eab42b2066229569934b936a5e7",
         "urls": [
+            "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/releases/download/v3.11.3/protoc-3.11.3-linux-x86_64.zip",
             "https://github.com/protocolbuffers/protobuf/releases/download/v3.11.3/protoc-3.11.3-linux-x86_64.zip",
         ],
     },
@@ -69,6 +74,7 @@ dependencies = {
         "build_file": "@rules_proto//proto/private:BUILD.protoc",
         "sha256": "b9684666c28cb37b532470df4df85f0238a3df610d3b9a5d03ce4222b0cd5e12",
         "urls": [
+            "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/releases/download/v3.11.3/protoc-3.11.3-osx-x86_32.zip",
             "https://github.com/protocolbuffers/protobuf/releases/download/v3.11.3/protoc-3.11.3-osx-x86_32.zip",
         ],
     },
@@ -76,20 +82,23 @@ dependencies = {
         "build_file": "@rules_proto//proto/private:BUILD.protoc",
         "sha256": "a02dc07c3776de214c3dff4025b33269aebd0fc03aa8e791e7025df43c06e219",
         "urls": [
+            "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/releases/download/v3.11.3/protoc-3.11.3-osx-x86_64.zip",
             "https://github.com/protocolbuffers/protobuf/releases/download/v3.11.3/protoc-3.11.3-osx-x86_64.zip",
         ],
     },
     "com_google_protobuf_protoc_windows_x86_32": {
-        "build_file": "@rules_proto//proto/private:BUILD.protoc_windows",
+        "build_file": "@rules_proto//proto/private:BUILD.protoc",
         "sha256": "63755dd0018e005293b8ef0cd21e348f420d466b94c54285e3e2593c22e8a74c",
         "urls": [
+            "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/releases/download/v3.11.3/protoc-3.11.3-win32.zip",
             "https://github.com/protocolbuffers/protobuf/releases/download/v3.11.3/protoc-3.11.3-win32.zip",
         ],
     },
     "com_google_protobuf_protoc_windows_x86_64": {
-        "build_file": "@rules_proto//proto/private:BUILD.protoc_windows",
+        "build_file": "@rules_proto//proto/private:BUILD.protoc",
         "sha256": "1490944d3bbf77b58bcbd175fef6fbf14cc9c20f79be06c4be827641af1c6ca2",
         "urls": [
+            "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/releases/download/v3.11.3/protoc-3.11.3-win64.zip",
             "https://github.com/protocolbuffers/protobuf/releases/download/v3.11.3/protoc-3.11.3-win64.zip",
         ],
     },
@@ -98,6 +107,7 @@ dependencies = {
         "sha256": "29daf0159f0cf552fcff60b49d8bcd4f08f08506d2da6e41b07058ec50cfeaec",
         "strip_prefix": "rules_cc-b7fe9697c0c76ab2fd431a891dbb9a6a32ed7c3e",
         "urls": [
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_cc/archive/b7fe9697c0c76ab2fd431a891dbb9a6a32ed7c3e.tar.gz",
             "https://github.com/bazelbuild/rules_cc/archive/b7fe9697c0c76ab2fd431a891dbb9a6a32ed7c3e.tar.gz",
         ],
     },
@@ -106,6 +116,7 @@ dependencies = {
         "sha256": "f5a3e477e579231fca27bf202bb0e8fbe4fc6339d63b38ccb87c2760b533d1c3",
         "strip_prefix": "rules_java-981f06c3d2bd10225e85209904090eb7b5fb26bd",
         "urls": [
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_java/archive/981f06c3d2bd10225e85209904090eb7b5fb26bd.tar.gz",
             "https://github.com/bazelbuild/rules_java/archive/981f06c3d2bd10225e85209904090eb7b5fb26bd.tar.gz",
         ],
     },
@@ -114,6 +125,7 @@ dependencies = {
         "sha256": "e5470e92a18aa51830db99a4d9c492cc613761d5bdb7131c04bd92b9834380f6",
         "strip_prefix": "rules_python-4b84ad270387a7c439ebdccfd530e2339601ef27",
         "urls": [
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_python/archive/4b84ad270387a7c439ebdccfd530e2339601ef27.tar.gz",
             "https://github.com/bazelbuild/rules_python/archive/4b84ad270387a7c439ebdccfd530e2339601ef27.tar.gz",
         ],
     },
@@ -138,21 +150,45 @@ dependencies = {
     },
 }
 
-# TODO: should these be mirrored to mirror.bazel.build?
 maven_dependencies = {
     "com_google_protobuf_protobuf_java": {
         "jar_sha256": "4e567f364f5608606616ef764e801d66a52e5241577ad7405f519a3a8a6802bb",
-        "jar_urls": ["https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java/3.11.3/protobuf-java-3.11.3.jar"],
+        "jar_urls": [
+            "https://mirror.bazel.build/repo1.maven.org/maven2/com/google/protobuf/protobuf-java/3.11.3/protobuf-java-3.11.3.jar",
+            "https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java/3.11.3/protobuf-java-3.11.3.jar",
+        ],
         "licenses": ["notice"],
         "srcjar_sha256": "9d2ee817e71c63f197271d425b11dac1414926302eea1d2eaae5e4fd2ca31d5d",
-        "srcjar_urls": ["https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java/3.11.3/protobuf-java-3.11.3-sources.jar"],
+        "srcjar_urls": [
+            "https://mirror.bazel.build/repo1.maven.org/maven2/com/google/protobuf/protobuf-java/3.11.3/protobuf-java-3.11.3-sources.jar",
+            "https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java/3.11.3/protobuf-java-3.11.3-sources.jar",
+        ],
+    },
+    "com_google_protobuf_protobuf_java_util": {
+        "jar_sha256": "5650c66dc2c617fd0b8f58e148b42a6c6a1f57ddbef4cbe86302aefff99ea025",
+        "jar_urls": [
+            "https://mirror.bazel.build/repo1.maven.org/maven2/com/google/protobuf/protobuf-java-util/3.11.3/protobuf-java-util-3.11.3.jar",
+            "https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java-util/3.11.3/protobuf-java-util-3.11.3.jar",
+        ],
+        "licenses": ["notice"],
+        "srcjar_sha256": "7a4750176c46541429da8374be5fbb4b6665f9c59e17d062cfe098d74296bd40",
+        "srcjar_urls": [
+            "https://mirror.bazel.build/repo1.maven.org/maven2/com/google/protobuf/protobuf-java-util/3.11.3/protobuf-java-util-3.11.3-sources.jar",
+            "https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java-util/3.11.3/protobuf-java-util-3.11.3-sources.jar",
+        ],
     },
     "com_google_protobuf_protobuf_javalite": {
         "jar_sha256": "5ff32ba40ce12b859898600a967a69094ae38bb57f619cf08c2160ae376174b6",
-        "jar_urls": ["https://repo1.maven.org/maven2/com/google/protobuf/protobuf-javalite/3.11.3/protobuf-javalite-3.11.3.jar"],
+        "jar_urls": [
+            "https://mirror.bazel.build/repo1.maven.org/maven2/com/google/protobuf/protobuf-javalite/3.11.3/protobuf-javalite-3.11.3.jar",
+            "https://repo1.maven.org/maven2/com/google/protobuf/protobuf-javalite/3.11.3/protobuf-javalite-3.11.3.jar",
+        ],
         "licenses": ["notice"],
         "srcjar_sha256": "6eeb3fa7f7bae8b41847cf49858454b1dd1a6859f0cfe50ffb6f846c5e027d49",
-        "srcjar_urls": ["https://repo1.maven.org/maven2/com/google/protobuf/protobuf-javalite/3.11.3/protobuf-javalite-3.11.3-sources.jar"],
+        "srcjar_urls": [
+            "https://mirror.bazel.build/repo1.maven.org/maven2/com/google/protobuf/protobuf-javalite/3.11.3/protobuf-javalite-3.11.3-sources.jar",
+            "https://repo1.maven.org/maven2/com/google/protobuf/protobuf-javalite/3.11.3/protobuf-javalite-3.11.3-sources.jar",
+        ],
     },
 }
 
@@ -170,13 +206,18 @@ protobuf_workspace = repository_rule(
     },
 )
 
-def protoc_binary(name, src, executable, **kwargs):
+def protoc_binary(name, srcs, executable, **kwargs):
+    """protoc_binary makes a copy of the protoc binary to bazel-bin.
+
+This is a workaround to make sure protoc can be used with attributes
+which don't allow files."""
+    # TODO(yannic) replace this with a symlink after https://github.com/bazelbuild/bazel/pull/10695
     native.genrule(
         name = name,
         executable = True,
-        srcs = [src],
+        srcs = srcs,
         outs = [executable],
-        cmd_bash = "cp $< $@&&chmod +x $@",
+        cmd_bash = "cp $< $@ && chmod +x $@",
         cmd_bat = "copy $< $@",
         **kwargs
     )

--- a/proto/private/dependencies.bzl
+++ b/proto/private/dependencies.bzl
@@ -16,74 +16,73 @@
 
 dependencies = {
     "bazel_skylib": {
-        "sha256": "9245b0549e88e356cd6a25bf79f97aa19332083890b7ac6481a2affb6ada9752",
-        "strip_prefix": "bazel-skylib-0.9.0",
+        "sha256": "97e70364e9249702246c0e9444bccdc4b847bed1eb03c5a3ece4f83dfe6abc44",
         "urls": [
-            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/archive/0.9.0.tar.gz",
-            "https://github.com/bazelbuild/bazel-skylib/archive/0.9.0.tar.gz",
+            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.0.2/bazel-skylib-1.0.2.tar.gz",
+            "https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.2/bazel-skylib-1.0.2.tar.gz",
         ],
     },
     "com_google_protobuf_protoc_linux_aarch64": {
         "build_file": "@rules_proto//proto/private:BUILD.protoc",
-        "sha256": "45276570e524c50f6ce82ed71ba87c75f0c8c69ca89adbf86ce0000049df27e5",
+        "sha256": "3994233e61c287a377a9134e658ca3034924849f0e3a82d12b0e6efa2bed4b46",
         "urls": [
-            "https://github.com/protocolbuffers/protobuf/releases/download/v3.10.0/protoc-3.10.0-linux-aarch_64.zip",
+            "https://github.com/protocolbuffers/protobuf/releases/download/v3.11.3/protoc-3.11.3-linux-aarch_64.zip",
         ],
     },
     "com_google_protobuf_protoc_linux_ppc": {
         "build_file": "@rules_proto//proto/private:BUILD.protoc",
-        "sha256": "7ab112ca489dcdd3cb5d3e5868707831ed96e913d9978523f2cb890ff1835324",
+        "sha256": "0dc5bf7eea3ee742ea7f56f51a229dac18e2deef330d5ccaef75c6d629469be7",
         "urls": [
-            "https://github.com/protocolbuffers/protobuf/releases/download/v3.10.0/protoc-3.10.0-linux-ppcle_64.zip",
+            "https://github.com/protocolbuffers/protobuf/releases/download/v3.11.3/protoc-3.11.3-linux-ppcle_64.zip",
         ],
     },
     "com_google_protobuf_protoc_linux_s390x": {
         "build_file": "@rules_proto//proto/private:BUILD.protoc",
-        "sha256": "0bf0d954d6cb97ec9fe8a1605e71f23cf2e8171ce0580ec6bd1b68197590a621",
+        "sha256": "81d8647b168af8f2cb3b1c2a665e35648a2c2906f3cb59382f39c7842ae639e3",
         "urls": [
-            "https://github.com/protocolbuffers/protobuf/releases/download/v3.10.0/protoc-3.10.0-linux-s390x_64.zip",
+            "https://github.com/protocolbuffers/protobuf/releases/download/v3.11.3/protoc-3.11.3-linux-s390x_64.zip",
         ],
     },
     "com_google_protobuf_protoc_linux_x86_32": {
         "build_file": "@rules_proto//proto/private:BUILD.protoc",
-        "sha256": "c1488147122a3b176f1b3f19d3b296eb807b0214df4588ad26d36dd852af8bc8",
+        "sha256": "840d0f8ef9886707b12414de4c100f62e6a5135b533040d3117e4b80db09e8ac",
         "urls": [
-            "https://github.com/protocolbuffers/protobuf/releases/download/v3.10.0/protoc-3.10.0-linux-x86_32.zip",
+            "https://github.com/protocolbuffers/protobuf/releases/download/v3.11.3/protoc-3.11.3-linux-x86_32.zip",
         ],
     },
     "com_google_protobuf_protoc_linux_x86_64": {
         "build_file": "@rules_proto//proto/private:BUILD.protoc",
-        "sha256": "213a591b42acb9e145ef9f3fe5f6037f14a14686065c508fcd547031243cc5d5",
+        "sha256": "39f5d64b0f31117c94651c880d0a776159e49eab42b2066229569934b936a5e7",
         "urls": [
-            "https://github.com/protocolbuffers/protobuf/releases/download/v3.10.0/protoc-3.10.0-linux-x86_64.zip",
+            "https://github.com/protocolbuffers/protobuf/releases/download/v3.11.3/protoc-3.11.3-linux-x86_64.zip",
         ],
     },
     "com_google_protobuf_protoc_macos_x86_32": {
         "build_file": "@rules_proto//proto/private:BUILD.protoc",
-        "sha256": "49c732a8431fb5bd377082014162e24c7d09216797cf447ddffb74cd6adf2ef8",
+        "sha256": "b9684666c28cb37b532470df4df85f0238a3df610d3b9a5d03ce4222b0cd5e12",
         "urls": [
-            "https://github.com/protocolbuffers/protobuf/releases/download/v3.10.0/protoc-3.10.0-osx-x86_32.zip",
+            "https://github.com/protocolbuffers/protobuf/releases/download/v3.11.3/protoc-3.11.3-osx-x86_32.zip",
         ],
     },
     "com_google_protobuf_protoc_macos_x86_64": {
         "build_file": "@rules_proto//proto/private:BUILD.protoc",
-        "sha256": "345d0b7652e37b7811e31b9659dee2b5418375197ab60d3cdc49213187310525",
+        "sha256": "a02dc07c3776de214c3dff4025b33269aebd0fc03aa8e791e7025df43c06e219",
         "urls": [
-            "https://github.com/protocolbuffers/protobuf/releases/download/v3.10.0/protoc-3.10.0-osx-x86_64.zip",
+            "https://github.com/protocolbuffers/protobuf/releases/download/v3.11.3/protoc-3.11.3-osx-x86_64.zip",
         ],
     },
     "com_google_protobuf_protoc_windows_x86_32": {
         "build_file": "@rules_proto//proto/private:BUILD.protoc_windows",
-        "sha256": "0533a9f0236988a128219e9568b35a7eead51c5c6f7df2d25c179ef031977fa2",
+        "sha256": "63755dd0018e005293b8ef0cd21e348f420d466b94c54285e3e2593c22e8a74c",
         "urls": [
-            "https://github.com/protocolbuffers/protobuf/releases/download/v3.10.0/protoc-3.10.0-win32.zip",
+            "https://github.com/protocolbuffers/protobuf/releases/download/v3.11.3/protoc-3.11.3-win32.zip",
         ],
     },
     "com_google_protobuf_protoc_windows_x86-64": {
         "build_file": "@rules_proto//proto/private:BUILD.protoc_windows",
         "sha256": "eca7c20ad11ae31abffee1f593dc5a0b2e3b97e5eff275125413d196a7513090",
         "urls": [
-            "https://github.com/protocolbuffers/protobuf/releases/download/v3.10.0/protoc-3.10.0-win64.zip",
+            "https://github.com/protocolbuffers/protobuf/releases/download/v3.11.3/protoc-3.11.3-win64.zip",
         ],
     },
     "com_github_protocolbuffers_protobuf": {
@@ -96,20 +95,18 @@ dependencies = {
     },
     # Dependency of `com_github_protocolbuffers_protobuf`.
     "rules_cc": {
-        "sha256": "bb8320b0bc1d8d01dc8c8e8c50edced8553655c03776960c1287d03dfbcac3e5",
-        "strip_prefix": "rules_cc-401380cd2279b83da0dcb86ecbac04a04805405b",
+        "sha256": "29daf0159f0cf552fcff60b49d8bcd4f08f08506d2da6e41b07058ec50cfeaec",
+        "strip_prefix": "rules_cc-b7fe9697c0c76ab2fd431a891dbb9a6a32ed7c3e",
         "urls": [
-            "https://mirror.bazel.build/github.com/bazelbuild/rules_cc/archive/401380cd2279b83da0dcb86ecbac04a04805405b.tar.gz",
-            "https://github.com/bazelbuild/rules_cc/archive/401380cd2279b83da0dcb86ecbac04a04805405b.tar.gz",
+            "https://github.com/bazelbuild/rules_cc/archive/b7fe9697c0c76ab2fd431a891dbb9a6a32ed7c3e.tar.gz",
         ],
     },
     # Dependency of `com_github_protocolbuffers_protobuf`.
     "rules_java": {
-        "sha256": "4e2f33528a66e3a9909910eaa5a562fb22f5b422513cdc3816fd01fbb6e2d08d",
-        "strip_prefix": "rules_java-166a046a27e118d578127759b413ee0b06aca3cd",
+        "sha256": "f5a3e477e579231fca27bf202bb0e8fbe4fc6339d63b38ccb87c2760b533d1c3",
+        "strip_prefix": "rules_java-981f06c3d2bd10225e85209904090eb7b5fb26bd",
         "urls": [
-            "https://mirror.bazel.build/github.com/bazelbuild/rules_java/archive/166a046a27e118d578127759b413ee0b06aca3cd.tar.gz",
-            "https://github.com/bazelbuild/rules_java/archive/166a046a27e118d578127759b413ee0b06aca3cd.tar.gz",
+            "https://github.com/bazelbuild/rules_java/archive/981f06c3d2bd10225e85209904090eb7b5fb26bd.tar.gz",
         ],
     },
     # Dependency of `com_github_protocolbuffers_protobuf`.
@@ -117,7 +114,6 @@ dependencies = {
         "sha256": "e5470e92a18aa51830db99a4d9c492cc613761d5bdb7131c04bd92b9834380f6",
         "strip_prefix": "rules_python-4b84ad270387a7c439ebdccfd530e2339601ef27",
         "urls": [
-            "https://mirror.bazel.build/github.com/bazelbuild/rules_python/archive/4b84ad270387a7c439ebdccfd530e2339601ef27.tar.gz",
             "https://github.com/bazelbuild/rules_python/archive/4b84ad270387a7c439ebdccfd530e2339601ef27.tar.gz",
         ],
     },
@@ -142,49 +138,45 @@ dependencies = {
     },
 }
 
+# TODO: should these be mirrored to mirror.bazel.build?
 maven_dependencies = {
     "com_google_protobuf_protobuf_java": {
-        "artifact": "com.google.protobuf:protobuf-java:3.10.0",
-        "sha1": "410b61dd0088aab4caa05739558d43df248958c9",
-        "sha1_src": "3ee94b1a2c1a74d9a27196e39c4bcf8dd0101e70",
+        "jar_urls": ["https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java/3.11.3/protobuf-java-3.11.3.jar"],
+        "jar_sha256": "4e567f364f5608606616ef764e801d66a52e5241577ad7405f519a3a8a6802bb",
+        "srcjar_urls": ["https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java/3.11.3/protobuf-java-3.11.3-sources.jar"],
+        "srcjar_sha256": "9d2ee817e71c63f197271d425b11dac1414926302eea1d2eaae5e4fd2ca31d5d",
+        "licenses": ["notice"],
     },
     "com_google_protobuf_protobuf_javalite": {
-        "artifact": "com.google.protobuf:protobuf-javalite:3.10.0",
-        "sha1": "a7e0350493910f45a208732992f8e519ade2fde5",
-        "sha1_src": "e43e8517029380185acc014f5dc6ee2ade484fb1",
+        "jar_urls": ["https://repo1.maven.org/maven2/com/google/protobuf/protobuf-javalite/3.11.3/protobuf-javalite-3.11.3.jar"],
+        "jar_sha256": "5ff32ba40ce12b859898600a967a69094ae38bb57f619cf08c2160ae376174b6",
+        "srcjar_urls": ["https://repo1.maven.org/maven2/com/google/protobuf/protobuf-javalite/3.11.3/protobuf-javalite-3.11.3-sources.jar"],
+        "srcjar_sha256": "6eeb3fa7f7bae8b41847cf49858454b1dd1a6859f0cfe50ffb6f846c5e027d49",
+        "licenses": ["notice"],
     },
 }
 
 def _protobuf_workspace_impl(ctx):
     ctx.symlink(ctx.attr._build, "BUILD")
+    ctx.symlink(ctx.attr._protobuf_bzl, "protobuf.bzl")
+    ctx.symlink(ctx.attr._protobuf_deps_bzl, "protobuf_deps.bzl")
 
 protobuf_workspace = repository_rule(
     implementation = _protobuf_workspace_impl,
     attrs = {
         "_build": attr.label(default = "@rules_proto//proto/private:BUILD.release"),
+        "_protobuf_bzl": attr.label(default="@com_github_protocolbuffers_protobuf//:protobuf.bzl"),
+        "_protobuf_deps_bzl": attr.label(default="@com_github_protocolbuffers_protobuf//:protobuf.bzl"),
     },
 )
 
-def _protoc_binary_impl(ctx):
-    args = ctx.actions.args()
-    args.add(ctx.file.src)
-    args.add(ctx.outputs.executable)
-    ctx.actions.run_shell(
-        inputs = [ctx.file.src],
-        outputs = [ctx.outputs.executable],
-        command = "cp $1 $2&&chmod +x $2",
-        arguments = [args],
+def protoc_binary(name, src, executable, **kwargs):
+    native.genrule(
+        name = name,
+        executable = True,
+        srcs = [src],
+        outs = [executable],
+        cmd_bash = "cp $< $@&&chmod +x $@",
+        cmd_bat = "copy $< $@",
+        **kwargs,
     )
-    return [DefaultInfo(executable = ctx.outputs.executable)]
-
-protoc_binary = rule(
-    implementation = _protoc_binary_impl,
-    attrs = {
-        "src": attr.label(
-            allow_single_file = True,
-            executable = True,
-            cfg = "target",
-        ),
-        "executable": attr.output(mandatory = True),
-    },
-)

--- a/proto/private/dependencies.bzl
+++ b/proto/private/dependencies.bzl
@@ -22,7 +22,70 @@ dependencies = {
             "https://github.com/bazelbuild/bazel-skylib/archive/0.9.0.tar.gz",
         ],
     },
-    "com_google_protobuf": {
+    "com_google_protobuf_protoc_linux_aarch64": {
+        "build_file": "@rules_proto//proto/private:BUILD.protoc",
+        "sha256": "45276570e524c50f6ce82ed71ba87c75f0c8c69ca89adbf86ce0000049df27e5",        
+        "urls": [
+            "https://github.com/protocolbuffers/protobuf/releases/download/v3.10.0/protoc-3.10.0-linux-aarch_64.zip",
+        ],
+    },
+    "com_google_protobuf_protoc_linux_ppc": {
+        "build_file": "@rules_proto//proto/private:BUILD.protoc",
+        "sha256": "7ab112ca489dcdd3cb5d3e5868707831ed96e913d9978523f2cb890ff1835324",
+        "urls": [
+            "https://github.com/protocolbuffers/protobuf/releases/download/v3.10.0/protoc-3.10.0-linux-ppcle_64.zip",
+        ],
+    },
+    "com_google_protobuf_protoc_linux_s390x": {
+        "build_file": "@rules_proto//proto/private:BUILD.protoc",
+        "sha256": "0bf0d954d6cb97ec9fe8a1605e71f23cf2e8171ce0580ec6bd1b68197590a621",
+        "urls": [
+            "https://github.com/protocolbuffers/protobuf/releases/download/v3.10.0/protoc-3.10.0-linux-s390x_64.zip",
+        ],
+    },
+    "com_google_protobuf_protoc_linux_x86_32": {
+        "build_file": "@rules_proto//proto/private:BUILD.protoc",
+        "sha256": "c1488147122a3b176f1b3f19d3b296eb807b0214df4588ad26d36dd852af8bc8",
+        "urls": [
+            "https://github.com/protocolbuffers/protobuf/releases/download/v3.10.0/protoc-3.10.0-linux-x86_32.zip",
+        ],
+    },
+    "com_google_protobuf_protoc_linux_x86_64": {
+        "build_file": "@rules_proto//proto/private:BUILD.protoc",
+        "sha256": "213a591b42acb9e145ef9f3fe5f6037f14a14686065c508fcd547031243cc5d5",
+        "urls": [
+            "https://github.com/protocolbuffers/protobuf/releases/download/v3.10.0/protoc-3.10.0-linux-x86_64.zip",
+        ],
+    },
+    "com_google_protobuf_protoc_macos_x86_32": {
+        "build_file": "@rules_proto//proto/private:BUILD.protoc",
+        "sha256": "49c732a8431fb5bd377082014162e24c7d09216797cf447ddffb74cd6adf2ef8",
+        "urls": [
+            "https://github.com/protocolbuffers/protobuf/releases/download/v3.10.0/protoc-3.10.0-osx-x86_32.zip",
+        ],
+    },
+    "com_google_protobuf_protoc_macos_x86_64": {
+        "build_file": "@rules_proto//proto/private:BUILD.protoc",
+        "sha256": "345d0b7652e37b7811e31b9659dee2b5418375197ab60d3cdc49213187310525",
+        "urls": [
+            "https://github.com/protocolbuffers/protobuf/releases/download/v3.10.0/protoc-3.10.0-osx-x86_64.zip",
+        ],
+    },
+    "com_google_protobuf_protoc_windows_x86_32": {
+        "build_file": "@rules_proto//proto/private:BUILD.protoc_windows",
+        "sha256": "0533a9f0236988a128219e9568b35a7eead51c5c6f7df2d25c179ef031977fa2",
+        "urls": [
+            "https://github.com/protocolbuffers/protobuf/releases/download/v3.10.0/protoc-3.10.0-win32.zip",
+        ],
+    },
+    "com_google_protobuf_protoc_windows_x86-64": {
+        "build_file": "@rules_proto//proto/private:BUILD.protoc_windows",
+        "sha256": "eca7c20ad11ae31abffee1f593dc5a0b2e3b97e5eff275125413d196a7513090",
+        "urls": [
+            "https://github.com/protocolbuffers/protobuf/releases/download/v3.10.0/protoc-3.10.0-win64.zip",
+        ],
+    },
+    "com_github_protocolbuffers_protobuf": {
         "sha256": "758249b537abba2f21ebc2d02555bf080917f0f2f88f4cbe2903e0e28c4187ed",
         "strip_prefix": "protobuf-3.10.0",
         "urls": [
@@ -30,7 +93,7 @@ dependencies = {
             "https://github.com/protocolbuffers/protobuf/archive/v3.10.0.tar.gz",
         ],
     },
-    # Dependency of `com_google_protobuf`.
+    # Dependency of `com_github_protocolbuffers_protobuf`.
     "rules_cc": {
         "sha256": "bb8320b0bc1d8d01dc8c8e8c50edced8553655c03776960c1287d03dfbcac3e5",
         "strip_prefix": "rules_cc-401380cd2279b83da0dcb86ecbac04a04805405b",
@@ -39,7 +102,7 @@ dependencies = {
             "https://github.com/bazelbuild/rules_cc/archive/401380cd2279b83da0dcb86ecbac04a04805405b.tar.gz",
         ],
     },
-    # Dependency of `com_google_protobuf`.
+    # Dependency of `com_github_protocolbuffers_protobuf`.
     "rules_java": {
         "sha256": "4e2f33528a66e3a9909910eaa5a562fb22f5b422513cdc3816fd01fbb6e2d08d",
         "strip_prefix": "rules_java-166a046a27e118d578127759b413ee0b06aca3cd",
@@ -48,7 +111,7 @@ dependencies = {
             "https://github.com/bazelbuild/rules_java/archive/166a046a27e118d578127759b413ee0b06aca3cd.tar.gz",
         ],
     },
-    # Dependency of `com_google_protobuf`.
+    # Dependency of `com_github_protocolbuffers_protobuf`.
     "rules_python": {
         "sha256": "e5470e92a18aa51830db99a4d9c492cc613761d5bdb7131c04bd92b9834380f6",
         "strip_prefix": "rules_python-4b84ad270387a7c439ebdccfd530e2339601ef27",
@@ -57,17 +120,17 @@ dependencies = {
             "https://github.com/bazelbuild/rules_python/archive/4b84ad270387a7c439ebdccfd530e2339601ef27.tar.gz",
         ],
     },
-    # Dependency of `com_google_protobuf`.
+    # Dependency of `com_github_protocolbuffers_protobuf`.
     "six": {
-        "build_file": "@com_google_protobuf//:third_party/six.BUILD",
+        "build_file": "@com_github_protocolbuffers_protobuf//:third_party/six.BUILD",
         "sha256": "d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73",
         "urls": [
             "https://pypi.python.org/packages/source/s/six/six-1.12.0.tar.gz",
         ],
     },
-    # Dependency of `com_google_protobuf`.
+    # Dependency of `com_github_protocolbuffers_protobuf`.
     "zlib": {
-        "build_file": "@com_google_protobuf//:third_party/zlib.BUILD",
+        "build_file": "@com_github_protocolbuffers_protobuf//:third_party/zlib.BUILD",
         "sha256": "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
         "strip_prefix": "zlib-1.2.11",
         "urls": [
@@ -75,3 +138,26 @@ dependencies = {
         ],
     },
 }
+
+maven_dependencies = {
+    "com_google_protobuf_protobuf_java":{
+        "artifact": "com.google.protobuf:protobuf-java:3.10.0",
+        "sha1": "410b61dd0088aab4caa05739558d43df248958c9",
+        "sha1_src": "3ee94b1a2c1a74d9a27196e39c4bcf8dd0101e70",
+    },
+    "com_google_protobuf_protobuf_javalite":{
+        "artifact": "com.google.protobuf:protobuf-javalite:3.10.0",
+        "sha1":"a7e0350493910f45a208732992f8e519ade2fde5",
+        "sha1_src": "e43e8517029380185acc014f5dc6ee2ade484fb1",
+    }
+}
+
+def _protobuf_workspace_impl(ctx):
+    ctx.symlink(ctx.attr._build, "BUILD")
+
+protobuf_workspace = repository_rule(
+    implementation = _protobuf_workspace_impl,
+    attrs = {
+        "_build": attr.label(default="@rules_proto//proto/private:BUILD.release")
+    }
+)

--- a/proto/private/dependencies.bzl
+++ b/proto/private/dependencies.bzl
@@ -202,7 +202,7 @@ protobuf_workspace = repository_rule(
     attrs = {
         "_build": attr.label(default = "@rules_proto//proto/private:BUILD.release"),
         "_protobuf_bzl": attr.label(default = "@com_github_protocolbuffers_protobuf//:protobuf.bzl"),
-        "_protobuf_deps_bzl": attr.label(default = "@com_github_protocolbuffers_protobuf//:protobuf.bzl"),
+        "_protobuf_deps_bzl": attr.label(default = "@com_github_protocolbuffers_protobuf//:protobuf_deps.bzl"),
     },
 )
 

--- a/proto/private/dependencies.bzl
+++ b/proto/private/dependencies.bzl
@@ -78,7 +78,7 @@ dependencies = {
             "https://github.com/protocolbuffers/protobuf/releases/download/v3.11.3/protoc-3.11.3-win32.zip",
         ],
     },
-    "com_google_protobuf_protoc_windows_x86-64": {
+    "com_google_protobuf_protoc_windows_x86_64": {
         "build_file": "@rules_proto//proto/private:BUILD.protoc_windows",
         "sha256": "eca7c20ad11ae31abffee1f593dc5a0b2e3b97e5eff275125413d196a7513090",
         "urls": [

--- a/proto/private/dependencies.bzl
+++ b/proto/private/dependencies.bzl
@@ -22,6 +22,14 @@ dependencies = {
             "https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.2/bazel-skylib-1.0.2.tar.gz",
         ],
     },
+    "com_github_protocolbuffers_protobuf": {
+        "sha256": "cf754718b0aa945b00550ed7962ddc167167bd922b842199eeb6505e6f344852",
+        "strip_prefix": "protobuf-3.11.3",
+        "urls": [
+            "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/archive/v3.11.3.tar.gz",
+            "https://github.com/protocolbuffers/protobuf/archive/v3.11.3.tar.gz",
+        ],
+    },
     "com_google_protobuf_protoc_linux_aarch64": {
         "build_file": "@rules_proto//proto/private:BUILD.protoc",
         "sha256": "3994233e61c287a377a9134e658ca3034924849f0e3a82d12b0e6efa2bed4b46",
@@ -85,14 +93,6 @@ dependencies = {
             "https://github.com/protocolbuffers/protobuf/releases/download/v3.11.3/protoc-3.11.3-win64.zip",
         ],
     },
-    "com_github_protocolbuffers_protobuf": {
-        "sha256": "cf754718b0aa945b00550ed7962ddc167167bd922b842199eeb6505e6f344852",
-        "strip_prefix": "protobuf-3.11.3",
-        "urls": [
-            "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/archive/v3.11.3.tar.gz",
-            "https://github.com/protocolbuffers/protobuf/archive/v3.11.3.tar.gz",
-        ],
-    },
     # Dependency of `com_github_protocolbuffers_protobuf`.
     "rules_cc": {
         "sha256": "29daf0159f0cf552fcff60b49d8bcd4f08f08506d2da6e41b07058ec50cfeaec",
@@ -141,17 +141,17 @@ dependencies = {
 # TODO: should these be mirrored to mirror.bazel.build?
 maven_dependencies = {
     "com_google_protobuf_protobuf_java": {
-        "jar_urls": ["https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java/3.11.3/protobuf-java-3.11.3.jar"],
         "jar_sha256": "4e567f364f5608606616ef764e801d66a52e5241577ad7405f519a3a8a6802bb",
-        "srcjar_urls": ["https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java/3.11.3/protobuf-java-3.11.3-sources.jar"],
+        "jar_urls": ["https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java/3.11.3/protobuf-java-3.11.3.jar"],
         "srcjar_sha256": "9d2ee817e71c63f197271d425b11dac1414926302eea1d2eaae5e4fd2ca31d5d",
+        "srcjar_urls": ["https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java/3.11.3/protobuf-java-3.11.3-sources.jar"],
         "licenses": ["notice"],
     },
     "com_google_protobuf_protobuf_javalite": {
-        "jar_urls": ["https://repo1.maven.org/maven2/com/google/protobuf/protobuf-javalite/3.11.3/protobuf-javalite-3.11.3.jar"],
         "jar_sha256": "5ff32ba40ce12b859898600a967a69094ae38bb57f619cf08c2160ae376174b6",
-        "srcjar_urls": ["https://repo1.maven.org/maven2/com/google/protobuf/protobuf-javalite/3.11.3/protobuf-javalite-3.11.3-sources.jar"],
+        "jar_urls": ["https://repo1.maven.org/maven2/com/google/protobuf/protobuf-javalite/3.11.3/protobuf-javalite-3.11.3.jar"],
         "srcjar_sha256": "6eeb3fa7f7bae8b41847cf49858454b1dd1a6859f0cfe50ffb6f846c5e027d49",
+        "srcjar_urls": ["https://repo1.maven.org/maven2/com/google/protobuf/protobuf-javalite/3.11.3/protobuf-javalite-3.11.3-sources.jar"],
         "licenses": ["notice"],
     },
 }

--- a/proto/private/generate_sums.sh
+++ b/proto/private/generate_sums.sh
@@ -1,5 +1,19 @@
 #!/usr/bin/bash
 
+# Copyright 2020 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -e
 VERSION=$1
 if [ -z "$VERSION" ]; then

--- a/proto/private/generate_sums.sh
+++ b/proto/private/generate_sums.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/bash
+
+set -e
+VERSION=$1
+if [ -z "$VERSION" ]; then
+  echo "usage: $0 version"
+  exit 1
+fi
+
+URLS=("https://mirror.bazel.build/github.com/protocolbuffers/protobuf/archive/v${VERSION}.tar.gz"
+"https://github.com/protocolbuffers/protobuf/releases/download/v${VERSION}/protoc-${VERSION}-linux-aarch_64.zip"
+"https://github.com/protocolbuffers/protobuf/releases/download/v${VERSION}/protoc-${VERSION}-linux-ppcle_64.zip"
+"https://github.com/protocolbuffers/protobuf/releases/download/v${VERSION}/protoc-${VERSION}-linux-s390x_64.zip"
+"https://github.com/protocolbuffers/protobuf/releases/download/v${VERSION}/protoc-${VERSION}-linux-x86_32.zip"
+"https://github.com/protocolbuffers/protobuf/releases/download/v${VERSION}/protoc-${VERSION}-linux-x86_64.zip"
+"https://github.com/protocolbuffers/protobuf/releases/download/v${VERSION}/protoc-${VERSION}-osx-x86_32.zip"
+"https://github.com/protocolbuffers/protobuf/releases/download/v${VERSION}/protoc-${VERSION}-osx-x86_64.zip"
+"https://github.com/protocolbuffers/protobuf/releases/download/v${VERSION}/protoc-${VERSION}-win32.zip"
+"https://github.com/protocolbuffers/protobuf/releases/download/v${VERSION}/protoc-${VERSION}-win64.zip"
+"https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java/${VERSION}/protobuf-java-${VERSION}.jar"
+"https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java/${VERSION}/protobuf-java-${VERSION}-sources.jar"
+"https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java-util/${VERSION}/protobuf-java-util-${VERSION}.jar"
+"https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java-util/${VERSION}/protobuf-java-util-${VERSION}-sources.jar"
+"https://repo1.maven.org/maven2/com/google/protobuf/protobuf-javalite/${VERSION}/protobuf-javalite-${VERSION}.jar"
+"https://repo1.maven.org/maven2/com/google/protobuf/protobuf-javalite/${VERSION}/protobuf-javalite-${VERSION}-sources.jar"
+)
+
+for U in ${URLS[@]}; do
+  MU="https://mirror.bazel.build/${U#"https://"}"
+  SUM=$(wget -q -O - $U|shasum -a 256|cut -d' ' -f1)
+  echo
+  echo '        "sha256": "'${SUM}'",'
+  echo '        "urls": ['
+  echo '            "'"$MU"'",'
+  echo '            "'"$U"'",'
+  echo '        ],'
+done
+
+echo
+echo "https://raw.githubusercontent.com/protocolbuffers/protobuf/v${VERSION}/protobuf_deps.bzl"

--- a/proto/private/generate_sums.sh
+++ b/proto/private/generate_sums.sh
@@ -39,7 +39,7 @@ URLS=("https://mirror.bazel.build/github.com/protocolbuffers/protobuf/archive/v$
 "https://repo1.maven.org/maven2/com/google/protobuf/protobuf-javalite/${VERSION}/protobuf-javalite-${VERSION}-sources.jar"
 )
 
-for U in ${URLS[@]}; do
+for U in "${URLS[@]}"; do
   MU="https://mirror.bazel.build/${U#"https://"}"
   SUM=$(wget -q -O - $U|shasum -a 256|cut -d' ' -f1)
   echo

--- a/proto/private/generate_sums.sh
+++ b/proto/private/generate_sums.sh
@@ -41,7 +41,7 @@ URLS=("https://mirror.bazel.build/github.com/protocolbuffers/protobuf/archive/v$
 
 for U in "${URLS[@]}"; do
   MU="https://mirror.bazel.build/${U#"https://"}"
-  SUM=$(wget -q -O - $U|shasum -a 256|cut -d' ' -f1)
+  SUM=$(wget -q -O - "$U"|shasum -a 256|cut -d' ' -f1)
   echo
   echo '        "sha256": "'"${SUM}"'",'
   echo '        "urls": ['

--- a/proto/private/generate_sums.sh
+++ b/proto/private/generate_sums.sh
@@ -43,7 +43,7 @@ for U in "${URLS[@]}"; do
   MU="https://mirror.bazel.build/${U#"https://"}"
   SUM=$(wget -q -O - $U|shasum -a 256|cut -d' ' -f1)
   echo
-  echo '        "sha256": "'${SUM}'",'
+  echo '        "sha256": "'"${SUM}"'",'
   echo '        "urls": ['
   echo '            "'"$MU"'",'
   echo '            "'"$U"'",'

--- a/proto/repositories.bzl
+++ b/proto/repositories.bzl
@@ -24,7 +24,7 @@ def rules_proto_dependencies():
         maybe(http_archive, name, **dependencies[name])
     for name in maven_dependencies:
         maybe(java_import_external, name, **maven_dependencies[name])
-    protobuf_workspace(name="com_google_protobuf")
+    protobuf_workspace(name = "com_google_protobuf")
 
 def rules_proto_toolchains():
     # Nothing to do here (yet).

--- a/proto/repositories.bzl
+++ b/proto/repositories.bzl
@@ -15,9 +15,9 @@
 """Dependencies and toolchains required to use rules_proto."""
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:java.bzl", "java_import_external")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("//proto/private:dependencies.bzl", "dependencies", "maven_dependencies", "protobuf_workspace")
-load("@bazel_tools//tools/build_defs/repo:java.bzl", "java_import_external")
 
 def rules_proto_dependencies():
     for name in dependencies:

--- a/proto/repositories.bzl
+++ b/proto/repositories.bzl
@@ -17,12 +17,13 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("//proto/private:dependencies.bzl", "dependencies", "maven_dependencies", "protobuf_workspace")
+load("@bazel_tools//tools/build_defs/repo:java.bzl", "java_import_external")
 
 def rules_proto_dependencies():
     for name in dependencies:
         maybe(http_archive, name, **dependencies[name])
     for name in maven_dependencies:
-        maybe(native.maven_jar, name, **maven_dependencies[name])
+        maybe(java_import_external, name, **maven_dependencies[name])
     protobuf_workspace(name="com_google_protobuf")
 
 def rules_proto_toolchains():

--- a/proto/repositories.bzl
+++ b/proto/repositories.bzl
@@ -16,11 +16,14 @@
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
-load("//proto/private:dependencies.bzl", "dependencies")
+load("//proto/private:dependencies.bzl", "dependencies", "maven_dependencies", "protobuf_workspace")
 
 def rules_proto_dependencies():
     for name in dependencies:
         maybe(http_archive, name, **dependencies[name])
+    for name in maven_dependencies:
+        maybe(native.maven_jar, name, **maven_dependencies[name])
+    protobuf_workspace(name="com_google_protobuf")
 
 def rules_proto_toolchains():
     # Nothing to do here (yet).

--- a/proto/repositories.bzl
+++ b/proto/repositories.bzl
@@ -20,6 +20,11 @@ load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("//proto/private:dependencies.bzl", "dependencies", "maven_dependencies", "protobuf_workspace")
 
 def rules_proto_dependencies():
+    """An utility method to load all dependencies of `rules_proto`.
+
+    Loads the remote repositories used by default in Bazel.
+    """
+
     for name in dependencies:
         maybe(http_archive, name, **dependencies[name])
     for name in maven_dependencies:
@@ -27,5 +32,7 @@ def rules_proto_dependencies():
     protobuf_workspace(name = "com_google_protobuf")
 
 def rules_proto_toolchains():
+    """An utility method to load all Protobuf toolchains."""
+
     # Nothing to do here (yet).
     pass


### PR DESCRIPTION
Here's my first stab at implementing issue #35 
I wasn't sure if this code should go here, in https://github.com/protocolbuffers/protobuf or in a separate repo.

This creates a stub workspace with aliases for everything in @com_google_protobuf that either points to the real thing from the protobuf repo, or a binary if it's available. This is mostly working, however I have a few problems:
 - It appears aliases don't work for .bzl files. I think we'd either need to copy the .bzl files into this stub workspace, or put the binary aliases directly into the real @com_google_protobuf BUIlD file.
- I'm not sure if this is working for java_proto_libraries. It seems like they may still be depending on the custom built protoc somehow. 