### PR TITLE
Fix immutable frozen set bug in defs.bzl

### DIFF
--- a/proto/defs.bzl
+++ b/proto/defs.bzl
@@ -20,7 +20,7 @@ _MIGRATION_TAG = "__PROTO_RULES_MIGRATION_DO_NOT_USE_WILL_BREAK__"
 
 def _add_migration_tag(attrs):
     if "tags" in attrs and attrs["tags"] != None:
-        attrs["tags"] += [_MIGRATION_TAG]
+        attrs["tags"] = attrs["tags"] + [_MIGRATION_TAG]
     else:
         attrs["tags"] = [_MIGRATION_TAG]
     return attrs

--- a/tests/load_from_macro/BUILD
+++ b/tests/load_from_macro/BUILD
@@ -1,0 +1,22 @@
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("//proto:defs.bzl", "proto_library")
+load(":tags.bzl", "TAGS")
+
+proto_library(
+    name = "foo",
+    srcs = ["foo.proto"],
+    tags = TAGS,
+)

--- a/tests/load_from_macro/foo.proto
+++ b/tests/load_from_macro/foo.proto
@@ -1,0 +1,17 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package rules_proto.tests;

--- a/tests/load_from_macro/tags.bzl
+++ b/tests/load_from_macro/tags.bzl
@@ -1,0 +1,17 @@
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Example tags defined in a separate file.
+"""
+TAGS = ["first_tag", "second_tag"]


### PR DESCRIPTION
When adding tags to a native cc_library rule that is created through a macro we
were not properly considering the case where the tags came from a different
file and therefore were frozen. This caused an error.

This change was originally submitted by @oquenchil as
https://github.com/bazelbuild/rules_cc/commit/cfe68f6bc79dea602f2f6a767797f94a5904997f