### PR TITLE
Allow for frozen tags set

### DIFF
--- a/proto/defs.bzl
+++ b/proto/defs.bzl
@@ -20,7 +20,7 @@ _MIGRATION_TAG = "__PROTO_RULES_MIGRATION_DO_NOT_USE_WILL_BREAK__"
 
 def _add_migration_tag(attrs):
     if "tags" in attrs and attrs["tags"] != None:
-        attrs["tags"] += [_MIGRATION_TAG]
+        attrs["tags"] = attrs["tags"] + [_MIGRATION_TAG]
     else:
         attrs["tags"] = [_MIGRATION_TAG]
     return attrs


### PR DESCRIPTION
If the tags come from external, they are immutable.

Fixes the following error:

rules_proto/proto/defs.bzl", line 23, in _add_migration_tag
		attrs["tags"] += [_MIGRATION_TAG]
trying to mutate a frozen object

See https://github.com/bazelbuild/rules_cc/commit/cfe68f6bc79dea602f2f6a767797f94a5904997f for the same thing fixed in rules_cc.