### PR TITLE
Don't set language for Starlark files to Python

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,0 @@
-*.bzl linguist-language=Python
-BUILD linguist-language=Python


### PR DESCRIPTION
It seems like GitHub understands Starlark now, so the .gitattributes
file is no longer needed.