### PR TITLE
Add proto_toolchain rule

### DIFF
--- a/proto/BUILD
+++ b/proto/BUILD
@@ -1,1 +1,22 @@
-# Intentionally left empty (for now).
+load("@proto_bazel_config//:defs.bzl", "proto_toolchain_type")
+load("//proto:defs.bzl", "proto_toolchain")
+
+# The toolchain type used to distinguish proto toolchains.
+#
+# For Bazel versions that have `@bazel_tools//tools/proto:toolchain_type`, this
+# is an alias for that target.
+# Otherwise, it is a normal `toolchain_type` target.
+proto_toolchain_type(
+    name = "toolchain_type",
+    visibility = ["//visibility:public"],
+)
+
+proto_toolchain(
+    name = "default_toolchain",
+)
+
+toolchain(
+    name = "toolchain",
+    toolchain = ":default_toolchain",
+    toolchain_type = ":toolchain_type",
+)

--- a/proto/defs.bzl
+++ b/proto/defs.bzl
@@ -15,6 +15,7 @@
 """Starlark rules for building protocol buffers."""
 
 load("//proto/private:native.bzl", "NativeProtoInfo", "native_proto_common")
+load("//proto/private/rules:proto_toolchain.bzl", _proto_toolchain = "proto_toolchain")
 
 _MIGRATION_TAG = "__PROTO_RULES_MIGRATION_DO_NOT_USE_WILL_BREAK__"
 
@@ -48,6 +49,22 @@ def proto_library(**attrs):
 
     # buildifier: disable=native-proto
     native.proto_library(**_add_migration_tag(attrs))
+
+def proto_toolchain(**attrs):
+    """Bazel proto_toolchain rule.
+
+    https://docs.bazel.build/versions/master/be/protocol-buffer.html#proto_toolchain
+
+    Args:
+      **attrs: Rule attributes
+    """
+
+    # buildifier: disable=native-proto
+    if hasattr(native, "proto_toolchain"):
+        # This is Bazel 3.1.0 (or later).
+        native.proto_toolchain(**_add_migration_tag(attrs))
+        return
+    _proto_toolchain(**attrs)
 
 # Encapsulates information provided by `proto_library`.
 #

--- a/proto/private/repositories/BUILD
+++ b/proto/private/repositories/BUILD
@@ -1,0 +1,1 @@
+exports_files(["proto_bazel_config_defs.bzl"])

--- a/proto/private/repositories/proto_bazel_config.bzl
+++ b/proto/private/repositories/proto_bazel_config.bzl
@@ -1,0 +1,39 @@
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Contains a repository rule for configuring rules_proto."""
+
+_config = """
+# GENERATED CODE -- DO NOT EDIT!
+
+bazel_version = "{bazel_version}"
+""".strip()
+
+def _proto_bazel_config_impl(repository_ctx):
+    repository_ctx.file("BUILD")
+    repository_ctx.symlink(repository_ctx.attr.defs, "defs.bzl")
+
+    config = _config.format(
+        bazel_version = native.bazel_version,
+    )
+    repository_ctx.file("config.bzl", config)
+
+proto_bazel_config = repository_rule(
+    implementation = _proto_bazel_config_impl,
+    attrs = {
+        "defs": attr.label(
+            mandatory = True,
+        ),
+    },
+)

--- a/proto/private/repositories/proto_bazel_config_defs.bzl
+++ b/proto/private/repositories/proto_bazel_config_defs.bzl
@@ -1,0 +1,43 @@
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Implementation of `@proto_bazel_config//:defs.bzl`."""
+
+load("@bazel_skylib//lib:versions.bzl", "versions")
+load("//:config.bzl", "bazel_version")
+
+def proto_toolchain_type(name, visibility):
+    """Helper function for creating the proto toolchain type.
+
+    This macro creates an alias target if
+    `@bazel_tools//tools/proto:toolchain_type` exists,
+    and a new toolchain type otherwise.
+
+    Args:
+      name: The name of the target.
+      visibility: The visibility of the target.
+    """
+
+    if versions.is_at_least("3.1.0", bazel_version):
+        native.alias(
+            name = name,
+            actual = "@bazel_tools//tools/proto:toolchain_type",
+            visibility = visibility,
+        )
+        return
+
+    native.toolchain_type(
+        name = name,
+        visibility = visibility,
+    )

--- a/proto/private/rules/BUILD
+++ b/proto/private/rules/BUILD
@@ -1,0 +1,1 @@
+# Intentionally left empty (for now).

--- a/proto/private/rules/proto_toolchain.bzl
+++ b/proto/private/rules/proto_toolchain.bzl
@@ -1,0 +1,27 @@
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Starlark implementation of `proto_toolchain`."""
+
+def _proto_toolchain_impl(ctx):
+    return [
+        platform_common.ToolchainInfo(),
+    ]
+
+proto_toolchain = rule(
+    implementation = _proto_toolchain_impl,
+    provides = [
+        platform_common.ToolchainInfo,
+    ],
+)

--- a/proto/repositories.bzl
+++ b/proto/repositories.bzl
@@ -17,11 +17,26 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("//proto/private:dependencies.bzl", "dependencies")
+load("//proto/private/repositories:proto_bazel_config.bzl", "proto_bazel_config")
 
 def rules_proto_dependencies():
+    """An utility method to load all dependencies of `rules_proto`.
+
+    Loads the remote repositories used by default in Bazel.
+    """
+
     for name in dependencies:
         maybe(http_archive, name, **dependencies[name])
 
+    maybe(
+        proto_bazel_config,
+        "proto_bazel_config",
+        defs = "//proto/private/repositories:proto_bazel_config_defs.bzl",
+    )
+
 def rules_proto_toolchains():
-    # Nothing to do here (yet).
-    pass
+    """An utility method to load all Protobuf toolchains."""
+
+    native.register_toolchains(
+        "//proto:toolchain",
+    )


### PR DESCRIPTION
This change adds a proto toolchain configuration to `@rules_proto`.
To stay compatible with versions that do not have
`native.proto_toolchain` yet, this change also adds a API-compatible
Starlark `proto_toolchain`.

See https://github.com/bazelbuild/bazel/pull/10937