### PR TITLE
Create proto_descriptor_set

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -9,19 +9,29 @@ platforms:
   macos:
     build_targets:
       - "..."
+    test_targets:
+      - "..."
 
   rbe_ubuntu1604:
     build_targets:
+      - "..."
+    test_targets:
       - "..."
 
   ubuntu1604:
     build_targets:
       - "..."
+    test_targets:
+      - "..."
 
   ubuntu1804:
     build_targets:
       - "..."
+    test_targets:
+      - "..."
 
   windows:
     build_targets:
+      - "..."
+    test_targets:
       - "..."

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,11 +1,24 @@
 workspace(name = "rules_proto")
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
 
 rules_proto_dependencies()
 
 rules_proto_toolchains()
+
+# Test-only dependencies.
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "com_google_googletest",
+    sha256 = "9dc9157a9a1551ec7a7e43daea9a694a0bb5fb8bec81235d8a1e6ef64c716dcb",
+    strip_prefix = "googletest-release-1.10.0",
+    urls = [
+        "https://mirror.bazel.build/github.com/google/googletest/archive/release-1.10.0.tar.gz",
+        "https://github.com/google/googletest/archive/release-1.10.0.tar.gz",
+    ],
+)
 
 http_archive(
     name = "bazel_toolchains",

--- a/proto/defs.bzl
+++ b/proto/defs.bzl
@@ -15,6 +15,7 @@
 """Starlark rules for building protocol buffers."""
 
 load("//proto/private:native.bzl", "NativeProtoInfo", "native_proto_common")
+load("//proto/private/rules:proto_descriptor_set.bzl", _proto_descriptor_set = "proto_descriptor_set")
 
 _MIGRATION_TAG = "__PROTO_RULES_MIGRATION_DO_NOT_USE_WILL_BREAK__"
 
@@ -48,6 +49,8 @@ def proto_library(**attrs):
 
     # buildifier: disable=native-proto
     native.proto_library(**_add_migration_tag(attrs))
+
+proto_descriptor_set = _proto_descriptor_set
 
 # Encapsulates information provided by `proto_library`.
 #

--- a/proto/private/rules/BUILD
+++ b/proto/private/rules/BUILD
@@ -1,13 +1,14 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 bzl_library(
-    name = "defs",
+    name = "proto_descriptor_set",
     srcs = [
-        "defs.bzl",
+        "proto_descriptor_set.bzl",
     ],
-    visibility = ["//visibility:public"],
+    visibility = [
+        "//proto:__subpackages__",
+    ],
     deps = [
         "//proto/private:native",
-        "//proto/private/rules:proto_descriptor_set",
     ],
 )

--- a/proto/private/rules/proto_descriptor_set.bzl
+++ b/proto/private/rules/proto_descriptor_set.bzl
@@ -1,0 +1,70 @@
+# Copyright 2020 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A rule for generating a `FileDescriptorSet` with all transitive dependencies.
+
+This module contains the definition of `proto_descriptor_set`, a rule that
+collects all `FileDescriptorSet`s from its transitive dependencies and generates
+a single `FileDescriptorSet` containing all the `FileDescriptorProto` from them.
+"""
+
+load("//proto/private:native.bzl", ProtoInfo = "NativeProtoInfo")
+
+def _proto_descriptor_set_impl(ctx):
+    args = ctx.actions.args()
+
+    output = ctx.actions.declare_file("{}.pb".format(ctx.attr.name))
+    args.add(output)
+
+    descriptor_sets = depset(
+        transitive = [dep[ProtoInfo].transitive_descriptor_sets for dep in ctx.attr.deps],
+    )
+    args.add_all(descriptor_sets)
+
+    ctx.actions.run(
+        executable = ctx.executable._file_concat,
+        mnemonic = "ConcatFileDescriptorSet",
+        inputs = descriptor_sets,
+        outputs = [output],
+        arguments = [args],
+    )
+
+    return [
+        DefaultInfo(
+            files = depset([output]),
+            runfiles = ctx.runfiles(files = [output]),
+        ),
+    ]
+
+proto_descriptor_set = rule(
+    implementation = _proto_descriptor_set_impl,
+    attrs = {
+        "deps": attr.label_list(
+            mandatory = False,
+            providers = [ProtoInfo],
+            doc = """
+Sequence of `ProtoInfo`s to collect `FileDescriptorSet`s from.
+""".strip(),
+        ),
+        "_file_concat": attr.label(
+            default = "//tools/file_concat",
+            executable = True,
+            cfg = "exec",
+        ),
+    },
+    doc = """
+Collects all `FileDescriptorSet`s from `deps` and combines them into a single
+`FileDescriptorSet` containing all the `FileDescriptorProto`.
+""".strip(),
+)

--- a/tests/rules/proto_descriptor_set/BUILD
+++ b/tests/rules/proto_descriptor_set/BUILD
@@ -1,0 +1,49 @@
+load("@rules_cc//cc:defs.bzl", "cc_test")
+load("//proto:defs.bzl", "proto_descriptor_set", "proto_library")
+
+proto_library(
+    name = "empty_proto_library",
+)
+
+proto_descriptor_set(
+    name = "no_protos",
+    deps = [
+        ":empty_proto_library",
+    ],
+)
+
+proto_descriptor_set(
+    name = "well_known_protos",
+    deps = [
+        "@com_google_protobuf//:any_proto",
+        "@com_google_protobuf//:api_proto",
+        "@com_google_protobuf//:compiler_plugin_proto",
+        "@com_google_protobuf//:descriptor_proto",
+        "@com_google_protobuf//:duration_proto",
+        "@com_google_protobuf//:empty_proto",
+        "@com_google_protobuf//:field_mask_proto",
+        "@com_google_protobuf//:source_context_proto",
+        "@com_google_protobuf//:struct_proto",
+        "@com_google_protobuf//:timestamp_proto",
+        "@com_google_protobuf//:type_proto",
+        "@com_google_protobuf//:wrappers_proto",
+    ],
+)
+
+cc_test(
+    name = "proto_descriptor_set_test",
+    srcs = [
+        "proto_descriptor_set_test.cc",
+    ],
+    data = [
+        ":no_protos",
+        ":well_known_protos",
+    ],
+    deps = [
+        "//tests/utils:workspace_constants",
+        "@bazel_tools//tools/cpp/runfiles",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+        "@com_google_protobuf//:protobuf",
+    ],
+)

--- a/tests/rules/proto_descriptor_set/proto_descriptor_set_test.cc
+++ b/tests/rules/proto_descriptor_set/proto_descriptor_set_test.cc
@@ -1,0 +1,99 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <algorithm>
+#include <fstream>
+#include <memory>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "google/protobuf/descriptor.pb.h"
+#include "gtest/gtest.h"
+#include "tests/utils/workspace_constants.h"
+#include "tools/cpp/runfiles/runfiles.h"
+
+using bazel::tools::cpp::runfiles::Runfiles;
+using google::protobuf::FileDescriptorProto;
+using google::protobuf::FileDescriptorSet;
+
+namespace rulesproto {
+namespace {
+
+std::string GetRlocation(const std::string& file) {
+  static std::unique_ptr<Runfiles> runfiles(Runfiles::CreateForTest());
+  return runfiles->Rlocation(file);
+}
+
+template <typename T, typename K>
+bool Contains(const T& container, const K& key) {
+  return container.find(key) != container.end();
+}
+
+std::vector<std::string> ReadFileDescriptorSet(const std::string& path) {
+  std::ifstream input(path, std::ifstream::binary);
+  EXPECT_TRUE(input) << "Could not open " << path;
+
+  FileDescriptorSet file_descriptor_set;
+  EXPECT_TRUE(file_descriptor_set.ParseFromIstream(&input));
+
+  std::set<std::string> unordered_proto_files;
+  for (FileDescriptorProto file_descriptor : file_descriptor_set.file()) {
+    EXPECT_FALSE(Contains(unordered_proto_files, file_descriptor.name()))
+        << "Already saw " << file_descriptor.name();
+    unordered_proto_files.insert(file_descriptor.name());
+  }
+
+  std::vector<std::string> proto_files(
+      unordered_proto_files.begin(), unordered_proto_files.end());
+  std::sort(proto_files.begin(), proto_files.end());
+  return proto_files;
+}
+
+void AssertFileDescriptorSetContains(
+    const std::string& path,
+    const std::vector<std::string>& expected_proto_files) {
+  std::vector<std::string> actual_proto_files =
+      ReadFileDescriptorSet(
+          GetRlocation(rulesproto::kWorkspaceRlocation + path));
+  EXPECT_EQ(expected_proto_files, actual_proto_files);
+}
+
+}  // namespace
+
+TEST(ProtoDescriptorSetTest, NoProtos) {
+  AssertFileDescriptorSetContains(
+      "tests/rules/proto_descriptor_set/no_protos.pb", {});
+}
+
+TEST(ProtoDescriptorSetTest, WellKnownProtos) {
+  AssertFileDescriptorSetContains(
+      "tests/rules/proto_descriptor_set/well_known_protos.pb",
+      {
+          "google/protobuf/any.proto",
+          "google/protobuf/api.proto",
+          "google/protobuf/compiler/plugin.proto",
+          "google/protobuf/descriptor.proto",
+          "google/protobuf/duration.proto",
+          "google/protobuf/empty.proto",
+          "google/protobuf/field_mask.proto",
+          "google/protobuf/source_context.proto",
+          "google/protobuf/struct.proto",
+          "google/protobuf/timestamp.proto",
+          "google/protobuf/type.proto",
+          "google/protobuf/wrappers.proto",
+      });
+}
+
+}  // namespace rulesproto

--- a/tests/utils/BUILD
+++ b/tests/utils/BUILD
@@ -1,0 +1,12 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "workspace_constants",
+    testonly = True,
+    hdrs = [
+        "workspace_constants.h",
+    ],
+    visibility = [
+        "//tests:__subpackages__",
+    ],
+)

--- a/tests/utils/workspace_constants.h
+++ b/tests/utils/workspace_constants.h
@@ -1,0 +1,26 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Contains WORKSPACE-related constants (e.g. the rlocation prefix).
+//
+// This file exists so that users that prefer to vendor all their dependencies
+// can create their own (private) version of this file that defines values that
+// make sense for their workspace instead of, e.g., relying on fragile Copybara
+// transformations.
+
+namespace rulesproto {
+
+constexpr char kWorkspaceRlocation[] = "rules_proto/";
+
+}  // namespace rulesproto

--- a/tools/file_concat/BUILD
+++ b/tools/file_concat/BUILD
@@ -1,0 +1,9 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary")
+
+cc_binary(
+    name = "file_concat",
+    srcs = [
+        "main.cc",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/tools/file_concat/main.cc
+++ b/tools/file_concat/main.cc
@@ -18,7 +18,7 @@
 
 namespace {
 
-constexpr size_t kBufferSize = 1024 * 1024;  // 1 MB
+constexpr size_t kBufferSize = 4096;  // 4kB
 
 // Return codes.
 constexpr int kOk = 0;

--- a/tools/file_concat/main.cc
+++ b/tools/file_concat/main.cc
@@ -1,0 +1,65 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <fstream>
+#include <iostream>
+#include <string>
+
+namespace {
+
+constexpr size_t kBufferSize = 1024 * 1024;  // 1 MB
+
+// Return codes.
+constexpr int kOk = 0;
+constexpr int kUsageError = 1;
+constexpr int kIOError = 2;
+
+}  // namespace
+
+int main(int argc, const char* argv[]) {
+  if (argc < 2) {
+    std::cout << "Usage: " << argv[0] << " <output> <inputs...>" << std::endl;
+    return kUsageError;
+  }
+
+  std::string output_path(argv[1]);
+  std::ofstream output(output_path, std::ofstream::binary);
+  if (!output) {
+    std::cerr << "Could not open output file " << output_path << std::endl;
+    return kIOError;
+  }
+
+  for (int i = 2; i < argc; i++) {
+    std::string input_path(argv[i]);
+    std::ifstream input(input_path, std::ifstream::binary);
+    if (!input) {
+      std::cerr << "Could not open input file " << output_path << std::endl;
+      return kIOError;
+    }
+
+    char buffer[kBufferSize];
+    while (input) {
+      if (!input.read(buffer, kBufferSize) && !input.eof()) {
+        std::cerr << "Error reading from " << input_path << std::endl;
+        return kIOError;
+      }
+      if (!output.write(buffer, input.gcount())) {
+        std::cerr << "Error writing to " << output_path << std::endl;
+        return kIOError;
+      }
+    }
+  }
+
+  return kOk;
+}


### PR DESCRIPTION
This change adds a rule that generates a single `FileDescriptorSet` for
all its transitive dependencies.

Fixes #45