### PR TITLE
RFC: Use precompiled libprotobuf.a and libprotobuf-lite.a for macOS x86_64 host/exec configuration

### DIFF
--- a/proto/private/BUILD.protobuf_cc
+++ b/proto/private/BUILD.protobuf_cc
@@ -1,0 +1,33 @@
+LINK_OPTS = [
+    "-lpthread",
+    "-lm",
+]
+
+cc_import(
+    name = "protobuf_lite_import",
+    static_library = "libprotobuf-lite.a",
+)
+
+cc_import(
+    name = "protobuf_import",
+    static_library = "libprotobuf.a",
+)
+
+cc_library(
+    name = "protobuf_lite",
+    linkopts = LINK_OPTS,
+    visibility = ["//visibility:public"],
+    deps = [":protobuf_lite_import"],
+)
+
+cc_library(
+    name = "protobuf",
+    linkopts = LINK_OPTS,
+    visibility = ["//visibility:public"],
+    deps = [
+        ":protobuf_import",
+        ":protobuf_lite",
+        "@com_github_protocolbuffers_protobuf//:protobuf_headers",
+        "@zlib",
+    ],
+)

--- a/proto/private/BUILD.release
+++ b/proto/private/BUILD.release
@@ -1,5 +1,20 @@
 load("@rules_proto//proto:defs.bzl", "proto_lang_toolchain")
 
+WELL_KNOWN_PROTO_KEYS = [
+    "any",
+    "api",
+    "compiler_plugin",
+    "descriptor",
+    "duration",
+    "empty",
+    "field_mask",
+    "source_context",
+    "struct",
+    "timestamp",
+    "type",
+    "wrappers",
+]
+
 # Use precompiled binaries where possible.
 alias(
     name = "protoc",
@@ -14,6 +29,32 @@ alias(
         ":windows-x86_64": "@com_google_protobuf_protoc_windows_x86_64//:protoc",
         "//conditions:default": "@com_github_protocolbuffers_protobuf//:protoc",
     }),
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "protobuf",
+    actual = select({
+        ":macos-x86_64": "@com_google_protobuf_protobuf_cc_macos_x86_64//:protobuf",
+        "//conditions:default": "@com_github_protocolbuffers_protobuf//:protobuf",
+    }),
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "protobuf_lite",
+    actual = select({
+        ":macos-x86_64": "@com_google_protobuf_protobuf_cc_macos_x86_64//:protobuf_lite",
+        "//conditions:default": "@com_github_protocolbuffers_protobuf//:protobuf_lite",
+    }),
+    visibility = ["//visibility:public"],
+)
+
+proto_lang_toolchain(
+    name = "cc_toolchain",
+    blacklisted_protos = [proto + "_proto" for proto in WELL_KNOWN_PROTO_KEYS],
+    command_line = "--cpp_out=$(OUT)",
+    runtime = ":protobuf",
     visibility = ["//visibility:public"],
 )
 
@@ -69,7 +110,6 @@ redirect_targets = [
     "compiler_plugin_proto",
     "descriptor_proto",
     "cc_wkt_protos",
-    "cc_toolchain",
     "cc_test_protos_genproto",
     "cc_wkt_protos_genproto",
     "api_proto",
@@ -77,7 +117,6 @@ redirect_targets = [
     "source_context_proto",
     "any_proto",
     "protoc_lib",
-    "protobuf",
 ]
 
 [

--- a/proto/private/dependencies.bzl
+++ b/proto/private/dependencies.bzl
@@ -30,6 +30,12 @@ dependencies = {
             "https://github.com/protocolbuffers/protobuf/archive/v3.13.0.tar.gz",
         ],
     },
+    "com_google_protobuf_protobuf_cc_macos_x86_64": {
+        "sha256": "0a5b436cc6be687df3767294952475adc81744c241595ec55b32efbfdd3d1f38",
+        "url": "https://homebrew.bintray.com/bottles/protobuf-3.13.0.mojave.bottle.tar.gz",
+        "build_file": "@rules_proto//proto/private:BUILD.protobuf_cc",
+        "strip_prefix": "protobuf/3.13.0/lib",
+    },
     "com_google_protobuf_protoc_linux_aarch64": {
         "build_file": "@rules_proto//proto/private:BUILD.protoc",
         "sha256": "5f6f59be05ce91425195dc689f5faa59284efb4799526b6f92a7a91efe5702fd",


### PR DESCRIPTION
Inspired by https://github.com/bazelbuild/rules_proto/pull/36, this tries to use prebuilt binaries of libprotobuf.a and libprotobuf-lite.a to reduce the compilation overhead of targets depending on `@com_google_protobuf//:protobuf` when building on macOS x86_64. Since the protobuf repo doesn't provide prebuilt libprotobuf.a and libprotobuf-lite.a, this uses the binaries from Homebrew.

This can be useful for rules_swift, as the compilation of its persistent worker is depending on protobuf, which can take a very long time, especially for small/non-cache projects.

Open question: Should we add a flag and make this an opt-in feature? Since people may want to compile everything from source for the best compatibility.