### PR TITLE
Set incomp. flag to use old feature in CI

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -7,24 +7,32 @@ buildifier:
 
 platforms:
   macos:
+    build_flags:
+      - "--incompatible_enable_exports_provider"
     build_targets:
       - "//..."
     test_targets:
       - "//..."
 
   rbe_ubuntu1604:
+    build_flags:
+      - "--incompatible_enable_exports_provider"
     build_targets:
       - "//..."
     test_targets:
       - "//..."
 
   ubuntu1804:
+    build_flags:
+      - "--incompatible_enable_exports_provider"
     build_targets:
       - "//..."
     test_targets:
       - "//..."
 
   windows:
+    build_flags:
+      - "--incompatible_enable_exports_provider"
     build_targets:
       - "//..."
     test_targets:


### PR DESCRIPTION
Set incompatible_enable_exports_provider to true for all CI builds.

This is a temporary fix to keep CI builds running until rules_proto is migrated to reflect https://github.com/bazelbuild/bazel/commit/7800ff9eb2dc0b4b3b7a2e6b8a908078f3e73d3b