### PR TITLE
Added `//proto:repositories` `bzl_library`

### DIFF
--- a/proto/BUILD
+++ b/proto/BUILD
@@ -11,3 +11,14 @@ bzl_library(
         "//proto/private/rules:proto_descriptor_set",
     ],
 )
+
+bzl_library(
+    name = "repositories",
+    srcs = [
+        "repositories.bzl",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//proto/private:dependencies",
+    ],
+)


### PR DESCRIPTION
This allows for `@rules_proto//proto:repositories.bzl` to be usable in [stardoc](https://github.com/bazelbuild/stardoc) docs generation.