### PR TITLE
Use universal protoc executables for macOS platforms

### DIFF
--- a/proto/private/BUILD.release
+++ b/proto/private/BUILD.release
@@ -6,7 +6,7 @@ genrule(
         "@com_google_protobuf_protoc_macos_aarch64//:file",
         "@com_google_protobuf_protoc_macos_x86_64//:protoc",
     ],
-    outs = ["protoc"],
+    outs = ["protoc_universal"],
     cmd = "lipo -create $(SRCS) -output $@",
     exec_compatible_with = ["@platforms//os:osx"],
     visibility = ["//visibility:public"],

--- a/proto/private/BUILD.release
+++ b/proto/private/BUILD.release
@@ -3,7 +3,7 @@ load("@rules_proto//proto:defs.bzl", "proto_lang_toolchain")
 genrule(
     name = "protoc_macos_universal",
     srcs = [
-        "@com_google_protobuf_protoc_macos_aarch64//:file",
+        "@com_google_protobuf_protoc_macos_aarch64//file",
         "@com_google_protobuf_protoc_macos_x86_64//:protoc",
     ],
     outs = ["protoc_universal"],

--- a/proto/private/BUILD.release
+++ b/proto/private/BUILD.release
@@ -9,6 +9,7 @@ genrule(
     outs = ["protoc_universal"],
     cmd = "lipo -create $(SRCS) -output $@",
     exec_compatible_with = ["@platforms//os:osx"],
+    executable = True,
     visibility = ["//visibility:public"],
 )
 

--- a/proto/private/BUILD.release
+++ b/proto/private/BUILD.release
@@ -1,5 +1,17 @@
 load("@rules_proto//proto:defs.bzl", "proto_lang_toolchain")
 
+genrule(
+    name = "protoc_macos_universal",
+    srcs = [
+        "@com_google_protobuf_protoc_macos_aarch64//:file",
+        "@com_google_protobuf_protoc_macos_x86_64//:protoc",
+    ],
+    outs = ["protoc"],
+    cmd = "lipo -create $(SRCS) -output $@",
+    exec_compatible_with = ["@platforms//os:osx"],
+    visibility = ["//visibility:public"],
+)
+
 # Use precompiled binaries where possible.
 alias(
     name = "protoc",
@@ -9,7 +21,7 @@ alias(
         ":linux-s390x": "@com_google_protobuf_protoc_linux_s390_64//:protoc",
         ":linux-x86_32": "@com_google_protobuf_protoc_linux_x86_32//:protoc",
         ":linux-x86_64": "@com_google_protobuf_protoc_linux_x86_64//:protoc",
-        ":macos-x86_64": "@com_google_protobuf_protoc_macos_x86_64//:protoc",
+        ":macos": ":protoc_macos_universal",
         ":windows-x86_32": "@com_google_protobuf_protoc_windows_x86_32//:protoc",
         ":windows-x86_64": "@com_google_protobuf_protoc_windows_x86_64//:protoc",
         "//conditions:default": "@com_github_protocolbuffers_protobuf//:protoc",
@@ -130,10 +142,9 @@ config_setting(
 )
 
 config_setting(
-    name = "macos-x86_64",
+    name = "macos",
     constraint_values = [
         "@platforms//os:osx",
-        "@platforms//cpu:x86_64",
     ],
 )
 

--- a/proto/repositories.bzl
+++ b/proto/repositories.bzl
@@ -14,7 +14,7 @@
 
 """Dependencies and toolchains required to use rules_proto."""
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
 load("@bazel_tools//tools/build_defs/repo:java.bzl", "java_import_external")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("//proto/private:dependencies.bzl", "dependencies", "maven_dependencies", "protobuf_workspace")
@@ -29,6 +29,19 @@ def rules_proto_dependencies():
         maybe(http_archive, name, **dependencies[name])
     for name in maven_dependencies:
         maybe(java_import_external, name, **maven_dependencies[name])
+
+    # TODO: Add this to proto/private/dependencies.bzl when it's released on
+    # GitHub (should be available since 3.20.0).
+    maybe(
+        http_file,
+        name = "com_google_protobuf_protoc_macos_aarch64",
+        executable = True,
+        urls = [
+            "https://repo1.maven.org/maven2/com/google/protobuf/protoc/3.17.3/protoc-3.17.3-osx-aarch_64.exe",
+        ],
+        sha256 = "2bfa83d8f881f8535d209dc3d2da9e84298390b80b723c00304f235a1b5fdba3",
+    )
+
     protobuf_workspace(name = "com_google_protobuf")
 
 def rules_proto_toolchains():


### PR DESCRIPTION
This allows protoc to run with native performance even if Apple silicon
Macs are declared as a macOS x86_64 platform. Since these are
precompiled binaries anyways, there's very little downside regarding
build times.
