### PR TITLE
Add `@rules_proto//proto:universal_tools` flag to allow building `protoc` as an universal binary

### DIFF
--- a/proto/BUILD
+++ b/proto/BUILD
@@ -1,4 +1,5 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 
 bzl_library(
     name = "defs",
@@ -21,4 +22,16 @@ bzl_library(
     deps = [
         "//proto/private:dependencies",
     ],
+)
+
+bool_flag(
+    name = "universal_tools",
+    build_setting_default = False,
+)
+
+config_setting(
+    name = "universal_tools_config",
+    flag_values = {
+        ":universal_tools": "true",
+    },
 )

--- a/proto/private/BUILD.release
+++ b/proto/private/BUILD.release
@@ -1,8 +1,29 @@
+load(
+    "@build_bazel_apple_support//rules:universal_binary.bzl",
+    "universal_binary",
+)
 load("@rules_proto//proto:defs.bzl", "proto_lang_toolchain")
+
+# This has to be named `protoc` because native rules refer to
+# `@com_google_protobuf//:protoc` in their implementation.
+alias(
+    name = "protoc",
+    actual = select({
+        "@rules_proto//proto:universal_tools_config": ":universal_protoc",
+        "//conditions:default": ":single_arch_protoc",
+    }),
+    visibility = ["//visibility:public"],
+)
+
+universal_binary(
+    name = "universal_protoc",
+    binary = ":single_arch_protoc",
+    visibility = ["//visibility:public"],
+)
 
 # Use precompiled binaries where possible.
 alias(
-    name = "protoc",
+    name = "single_arch_protoc",
     actual = select({
         ":linux-aarch64": "@com_google_protobuf_protoc_linux_aarch64//:protoc",
         ":linux-ppc": "@com_google_protobuf_protoc_linux_ppc//:protoc",

--- a/proto/private/dependencies.bzl
+++ b/proto/private/dependencies.bzl
@@ -22,6 +22,12 @@ dependencies = {
             "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.1.1/bazel-skylib-1.1.1.tar.gz",
         ],
     },
+    "build_bazel_apple_support": {
+        "sha256": "c604b75865c07f45828c7fffd5fdbff81415a9e84a68f71a9c1d8e3b2694e547",
+        "urls": [
+            "https://github.com/bazelbuild/apple_support/releases/download/0.12.1/apple_support.0.12.1.tar.gz",
+        ],
+    },
     "com_github_protocolbuffers_protobuf": {
         "sha256": "87407cd28e7a9c95d9f61a098a53cf031109d451a7763e7dd1253abf8b4df422",
         "strip_prefix": "protobuf-3.19.1",


### PR DESCRIPTION
Similar to https://github.com/bazelbuild/rules_swift/pull/712