### PR TITLE
proto_descriptor_set: export ProtoInfo with all deps

### DIFF
--- a/tests/rules/proto_descriptor_set/BUILD
+++ b/tests/rules/proto_descriptor_set/BUILD
@@ -1,12 +1,30 @@
 load("@rules_cc//cc:defs.bzl", "cc_test")
 load("//proto:defs.bzl", "proto_descriptor_set", "proto_library")
 
+proto_descriptor_set(
+    name = "no_deps",
+)
+
+proto_descriptor_set(
+    name = "no_deps_reexport",
+    deps = [
+        ":no_deps",
+    ],
+)
+
 proto_library(
     name = "empty_proto_library",
 )
 
 proto_descriptor_set(
     name = "no_protos",
+    deps = [
+        ":empty_proto_library",
+    ],
+)
+
+proto_descriptor_set(
+    name = "no_protos_reexport",
     deps = [
         ":empty_proto_library",
     ],
@@ -30,14 +48,25 @@ proto_descriptor_set(
     ],
 )
 
+proto_descriptor_set(
+    name = "well_known_protos_reexport",
+    deps = [
+        ":well_known_protos",
+    ],
+)
+
 cc_test(
     name = "proto_descriptor_set_test",
     srcs = [
         "proto_descriptor_set_test.cc",
     ],
     data = [
+        ":no_deps",
+        ":no_deps_reexport",
         ":no_protos",
+        ":no_protos_reexport",
         ":well_known_protos",
+        ":well_known_protos_reexport",
     ],
     deps = [
         "//tests/utils:workspace_constants",

--- a/tests/rules/proto_descriptor_set/proto_descriptor_set_test.cc
+++ b/tests/rules/proto_descriptor_set/proto_descriptor_set_test.cc
@@ -70,11 +70,40 @@ void AssertFileDescriptorSetContains(
   EXPECT_EQ(expected_proto_files, actual_proto_files);
 }
 
+void AssertFileDescriptorSetEquals(
+    const std::string& expected_path,
+    const std::string& actual_path) {
+  std::vector<std::string> expected_proto_files =
+      ReadFileDescriptorSet(
+          GetRlocation(rulesproto::kWorkspaceRlocation + expected_path));
+  std::vector<std::string> actual_proto_files =
+      ReadFileDescriptorSet(
+          GetRlocation(rulesproto::kWorkspaceRlocation + actual_path));
+  EXPECT_EQ(expected_proto_files, actual_proto_files);
+}
+
 }  // namespace
+
+TEST(ProtoDescriptorSetTest, NoDeps) {
+  AssertFileDescriptorSetContains(
+      "tests/rules/proto_descriptor_set/no_deps.pb", {});
+}
+
+TEST(ProtoDescriptorSetTest, NoDepsReexport) {
+  AssertFileDescriptorSetEquals(
+      "tests/rules/proto_descriptor_set/no_deps.pb",
+      "tests/rules/proto_descriptor_set/no_deps_reexport.pb");
+}
 
 TEST(ProtoDescriptorSetTest, NoProtos) {
   AssertFileDescriptorSetContains(
       "tests/rules/proto_descriptor_set/no_protos.pb", {});
+}
+
+TEST(ProtoDescriptorSetTest, NoProtosReexport) {
+  AssertFileDescriptorSetEquals(
+      "tests/rules/proto_descriptor_set/no_protos.pb",
+      "tests/rules/proto_descriptor_set/no_protos_reexport.pb");
 }
 
 TEST(ProtoDescriptorSetTest, WellKnownProtos) {
@@ -94,6 +123,12 @@ TEST(ProtoDescriptorSetTest, WellKnownProtos) {
           "google/protobuf/type.proto",
           "google/protobuf/wrappers.proto",
       });
+}
+
+TEST(ProtoDescriptorSetTest, WellKnownProtosReexport) {
+  AssertFileDescriptorSetEquals(
+      "tests/rules/proto_descriptor_set/well_known_protos.pb",
+      "tests/rules/proto_descriptor_set/well_known_protos_reexport.pb");
 }
 
 }  // namespace rulesproto


### PR DESCRIPTION
This allows `proto_descriptor_set` to depend on other
`proto_descriptor_set` targets.