### PR TITLE
Allow users to force protoc recompilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ command to automate the changes to your `BUILD` and `.bzl` files:
 buildifier --lint=fix --warnings=native-proto <path/to/BUILD>
 ```
 
+If the provided prebuilt binaries for `protoc` don't work for you, you can force
+`protoc` to be compiled by using the `recompile-protoc` bool flag:
+```bash
+bazel build --@rules_proto//proto:recompile-protoc <target>
+```
+
 ## Contributing
 
 Bazel and `rules_proto` are the work of many contributors.

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -1,4 +1,11 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+
+bool_flag(
+    name = "recompile-protoc",
+    build_setting_default = 0,
+    visibility = ["//visibility:public"],
+)
 
 bzl_library(
     name = "defs",

--- a/proto/private/BUILD.release
+++ b/proto/private/BUILD.release
@@ -4,6 +4,8 @@ load("@rules_proto//proto:defs.bzl", "proto_lang_toolchain")
 alias(
     name = "protoc",
     actual = select({
+        # on some platforms the prebuilt binaries don't work, so we allow users to force recompilcation
+        ":recompile": "@com_github_protocolbuffers_protobuf//:protoc",
         ":linux-aarch64": "@com_google_protobuf_protoc_linux_aarch64//:protoc",
         ":linux-ppc": "@com_google_protobuf_protoc_linux_ppc//:protoc",
         ":linux-s390x": "@com_google_protobuf_protoc_linux_s390_64//:protoc",
@@ -88,6 +90,11 @@ redirect_targets = [
     )
     for target in redirect_targets
 ]
+
+config_setting(
+    name = "recompile",
+    flag_values = {"@rules_proto//proto:recompile-protoc": "1"},
+)
 
 config_setting(
     name = "linux-aarch64",


### PR DESCRIPTION
I came upon this while trying to use `rules_proto` on nixos, which doesn't have `ld` in `/lib64/ld-linux-x86-64.so.2`, as is expected by the prebuilt binaries.

I'm open to hearing about better solutions. As far as I understand toolchains can be used for this purpose as well, but it seems like that will take a while, and this seems like an ok temporary solution.