### PR TITLE
[Zlib] update zlib version to zlib-1.2.12

### DIFF
--- a/proto/private/dependencies.bzl
+++ b/proto/private/dependencies.bzl
@@ -124,11 +124,11 @@ dependencies = {
     # Dependency of `com_github_protocolbuffers_protobuf`.
     "zlib": {
         "build_file": "@com_github_protocolbuffers_protobuf//:third_party/zlib.BUILD",
-        "sha256": "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
-        "strip_prefix": "zlib-1.2.11",
+        "sha256": "91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9",
+        "strip_prefix": "zlib-1.2.12",
         "urls": [
-            "https://mirror.bazel.build/zlib.net/zlib-1.2.11.tar.gz",
-            "https://zlib.net/zlib-1.2.11.tar.gz",
+            "https://mirror.bazel.build/zlib.net/zlib-1.2.12.tar.gz",
+            "https://zlib.net/zlib-1.2.12.tar.gz",
         ],
     },
 }


### PR DESCRIPTION
Issue: https://github.com/bazelbuild/rules_proto/pull/117

According to [zlib](https://zlib.net/) 
```
"Due to the bug fixes, any installations of 1.2.11 should be replaced with 1.2.12."
```