### PR TITLE
Bump rules_cc to 2f8c04c

### DIFF
--- a/proto/private/dependencies.bzl
+++ b/proto/private/dependencies.bzl
@@ -104,11 +104,11 @@ dependencies = {
     },
     # Dependency of `com_github_protocolbuffers_protobuf`.
     "rules_cc": {
-        "sha256": "29daf0159f0cf552fcff60b49d8bcd4f08f08506d2da6e41b07058ec50cfeaec",
-        "strip_prefix": "rules_cc-b7fe9697c0c76ab2fd431a891dbb9a6a32ed7c3e",
+        "sha256": "4aeb102efbcfad509857d7cb9c5456731e8ce566bfbf2960286a2ec236796cc3",
+        "strip_prefix": "rules_cc-2f8c04c04462ab83c545ab14c0da68c3b4c96191",
         "urls": [
-            "https://mirror.bazel.build/github.com/bazelbuild/rules_cc/archive/b7fe9697c0c76ab2fd431a891dbb9a6a32ed7c3e.tar.gz",
-            "https://github.com/bazelbuild/rules_cc/archive/b7fe9697c0c76ab2fd431a891dbb9a6a32ed7c3e.tar.gz",
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_cc/archive/2f8c04c04462ab83c545ab14c0da68c3b4c96191.tar.gz",
+            "https://github.com/bazelbuild/rules_cc/archive/2f8c04c04462ab83c545ab14c0da68c3b4c96191.tar.gz",
         ],
     },
     # Dependency of `com_github_protocolbuffers_protobuf`.


### PR DESCRIPTION
This is my first contribution to `rules_proto` -- greatly appreciate your patience! I've already signed the CLA on my own behalf.

Fixes https://github.com/bazelbuild/rules_proto/issues/95.

This bumps `rules_cc` to (as of writing) HEAD, authored ~21 days ago:
https://github.com/bazelbuild/rules_cc/commit/2f8c04c04462ab83c545ab14c0da68c3b4c96191

To verify, I:
- reproduced the error described in https://github.com/erenon/bazel_clang_tidy/issues/8
- Updated `bazel_clang_tidy`'s version of `rules_proto` to this commit, and verified that the error no longer occurred:

```
ouguoc:~/bazel_clang_tidy$ bazel build //example:app     --aspects clang_tidy/clang_tidy.bzl%clang_tidy_aspect     --output_groups=report
INFO: Analyzed target //example:app (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
INFO: From Run clang-tidy on example/app.cpp:
3005 warnings generated.
Suppressed 3005 warnings (3005 in non-user code).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
Aspect //clang_tidy:clang_tidy.bzl%clang_tidy_aspect of //example:app up-to-date:
  bazel-bin/example/example/app.cpp.app.clang-tidy.yaml
INFO: Elapsed time: 2.845s, Critical Path: 2.65s
INFO: 2 processes: 1 internal, 1 local.
INFO: Build completed successfully, 2 total actions
```