### PR TITLE
Add protobuf_lite target to protobuf_workspace

### DIFF
--- a/proto/private/BUILD.release
+++ b/proto/private/BUILD.release
@@ -79,6 +79,7 @@ redirect_targets = [
     "any_proto",
     "protoc_lib",
     "protobuf",
+    "protobuf_lite",
 ]
 
 [


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/rules_proto/issues/121.

This exposes the `@com_google_protobuf//:protobuf_lite` target, which is a common dependency.

To test this, I:

- built the target directly from `rules_proto`'s own workspace:
```
ouguoc:~/rules_proto$ bazel build @com_google_protobuf//:protobuf_lite
INFO: Analyzed target @com_google_protobuf//:protobuf_lite (38 packages loaded, 440 targets configured).
INFO: Found 1 target...
Target @com_github_protocolbuffers_protobuf//:protobuf_lite up-to-date:
  bazel-bin/external/com_github_protocolbuffers_protobuf/libprotobuf_lite.a
  bazel-bin/external/com_github_protocolbuffers_protobuf/libprotobuf_lite.so
INFO: Elapsed time: 1.201s, Critical Path: 0.13s
INFO: 3 processes: 2 internal, 1 linux-sandbox.
INFO: Build completed successfully, 3 total actions
```

- built the target in a project that uses `rules_proto`:
```
ouguoc:~/bazel_clang_tidy$ cat WORKSPACE
load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

http_archive(
    name = "rules_proto",
    sha256 = "8707a57525c20be715cf7993b174983d73507d5d3d1a9cb7d62f40b8ef829e0a",
    strip_prefix = "rules_proto-b7ffca6f334861d9e1d2987db5d64e97f441c899",
    urls = [
        # "https://mirror.bazel.build/github.com/bazelbuild/rules_proto/archive/c06f4b824b8047603bcf5c0c3868f2e590290576.tar.gz",
        "https://github.com/shaldengeki/rules_proto/archive/b7ffca6f334861d9e1d2987db5d64e97f441c899.tar.gz",
    ],
)

load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")

rules_proto_dependencies()

rules_proto_toolchains()
ouguoc:~/bazel_clang_tidy$ bazel build @com_google_protobuf//:protobuf_lite
INFO: Analyzed target @com_google_protobuf//:protobuf_lite (37 packages loaded, 439 targets configured).
INFO: Found 1 target...
Target @com_github_protocolbuffers_protobuf//:protobuf_lite up-to-date:
  bazel-bin/external/com_github_protocolbuffers_protobuf/libprotobuf_lite.a
  bazel-bin/external/com_github_protocolbuffers_protobuf/libprotobuf_lite.so
INFO: Elapsed time: 11.027s, Critical Path: 5.05s
INFO: 36 processes: 3 internal, 33 linux-sandbox.
INFO: Build completed successfully, 36 total actions
```