### PR TITLE
migrating to usage of rbe_preconfig and remove bazel-toolchains

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -29,7 +29,3 @@ http_archive(
         "https://github.com/bazelbuild/bazel-toolchains/archive/refs/tags/v5.1.2.tar.gz",
     ],
 )
-
-load("@bazel_toolchains//rules:rbe_repo.bzl", "rbe_autoconfig")
-
-rbe_autoconfig(name = "buildkite_config")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -26,8 +26,7 @@ http_archive(
     strip_prefix = "bazelci_rules-1.0.0",
     url = "https://github.com/bazelbuild/continuous-integration/releases/download/rules-1.0.0/bazelci_rules-1.0.0.tar.gz",
 )
+
 load("@bazelci_rules//:rbe_repo.bzl", "rbe_preconfig")
-rbe_preconfig(
-    name = "rbe_default",
-    toolchain = "ubuntu1604-bazel-java8",
-)
+
+rbe_preconfig(name="buildkite_config", toolchain = "ubuntu1804-bazel-java11")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -21,11 +21,13 @@ http_archive(
 )
 
 http_archive(
-    name = "bazel_toolchains",
-    sha256 = "02e4f3744f1ce3f6e711e261fd322916ddd18cccd38026352f7a4c0351dbda19",
-    strip_prefix = "bazel-toolchains-5.1.2",
-    urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/refs/tags/v5.1.2.tar.gz",
-        "https://github.com/bazelbuild/bazel-toolchains/archive/refs/tags/v5.1.2.tar.gz",
-    ],
+    name = "bazelci_rules",
+    sha256 = "eca21884e6f66a88c358e580fd67a6b148d30ab57b1680f62a96c00f9bc6a07e",
+    strip_prefix = "bazelci_rules-1.0.0",
+    url = "https://github.com/bazelbuild/continuous-integration/releases/download/rules-1.0.0/bazelci_rules-1.0.0.tar.gz",
+)
+load("@bazelci_rules//:rbe_repo.bzl", "rbe_preconfig")
+rbe_preconfig(
+    name = "rbe_default",
+    toolchain = "ubuntu1604-bazel-java8",
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -29,4 +29,7 @@ http_archive(
 
 load("@bazelci_rules//:rbe_repo.bzl", "rbe_preconfig")
 
-rbe_preconfig(name="buildkite_config", toolchain = "ubuntu1804-bazel-java11")
+rbe_preconfig(
+    name = "buildkite_config",
+    toolchain = "ubuntu1804-bazel-java11",
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -22,11 +22,11 @@ http_archive(
 
 http_archive(
     name = "bazel_toolchains",
-    sha256 = "1caf8584434d3e31be674067996be787cfa511fda2a0f05811131b588886477f",
-    strip_prefix = "bazel-toolchains-3.7.2",
+    sha256 = "02e4f3744f1ce3f6e711e261fd322916ddd18cccd38026352f7a4c0351dbda19",
+    strip_prefix = "bazel-toolchains-5.1.2",
     urls = [
-        "https://github.com/bazelbuild/bazel-toolchains/releases/download/3.7.2/bazel-toolchains-3.7.2.tar.gz",
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/3.7.2.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/refs/tags/v5.1.2.tar.gz",
+        "https://github.com/bazelbuild/bazel-toolchains/archive/refs/tags/v5.1.2.tar.gz",
     ],
 )
 


### PR DESCRIPTION
Ugrade bazel-toolchain to 5.1.2 to use constraints values from `@platforms`

https://github.com/bazelbuild/continuous-integration/issues/1404