### PR TITLE
Point proto_common to proto_common_do_not_use

### DIFF
--- a/proto/private/native.bzl
+++ b/proto/private/native.bzl
@@ -25,4 +25,4 @@
 NativeProtoInfo = ProtoInfo
 
 # buildifier: disable=native-proto
-native_proto_common = proto_common
+native_proto_common = proto_common_do_not_use


### PR DESCRIPTION
This has extra functions, like `compile`, `declare_generated_files`.

`proto_common_do_not_use` is available since bazel 5.3.0