### PR TITLE
Update protobuf to v21.7

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,7 +1,7 @@
 module(
     name = "rules_proto",
     compatibility_level = 1,
-    version = "5.3.0-21.5",
+    version = "5.3.0-21.7",
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.1.1")

--- a/proto/private/dependencies.bzl
+++ b/proto/private/dependencies.bzl
@@ -23,83 +23,83 @@ dependencies = {
         ],
     },
     "com_github_protocolbuffers_protobuf": {
-        "sha256": "4a7e87e4166c358c63342dddcde6312faee06ea9d5bb4e2fa87d3478076f6639",
-        "strip_prefix": "protobuf-21.5",
+        "sha256": "75be42bd736f4df6d702a0e4e4d30de9ee40eac024c4b845d17ae4cc831fe4ae",
+        "strip_prefix": "protobuf-21.7",
         "urls": [
-            "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/archive/v21.5.tar.gz",
-            "https://github.com/protocolbuffers/protobuf/archive/v21.5.tar.gz",
+            "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/archive/v21.7.tar.gz",
+            "https://github.com/protocolbuffers/protobuf/archive/v21.7.tar.gz",
         ],
     },
     "com_google_protobuf_protoc_linux_aarch64": {
         "build_file": "@rules_proto//proto/private:BUILD.protoc",
-        "sha256": "60744ee6be123f86921c86d83d0060a7261410e246eca9e7a5c195100a89d391",
+        "sha256": "2696a8f9a61ce67c510d000c88e2d0a8b5adf1f90514e461e8d8943c46d04737",
         "urls": [
-            "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/releases/download/v21.5/protoc-21.5-linux-aarch_64.zip",
-            "https://github.com/protocolbuffers/protobuf/releases/download/v21.5/protoc-21.5-linux-aarch_64.zip",
+            "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/releases/download/v21.7/protoc-21.7-linux-aarch_64.zip",
+            "https://github.com/protocolbuffers/protobuf/releases/download/v21.7/protoc-21.7-linux-aarch_64.zip",
         ],
     },
     "com_google_protobuf_protoc_linux_ppc": {
         "build_file": "@rules_proto//proto/private:BUILD.protoc",
-        "sha256": "72d6a66a8dc865928f5b4f33817fae650f3be53c79d762f9d1a9004d23981803",
+        "sha256": "ffa8298f1e64d25e09e2389edf8093fa1a70d34a042623aca769b4f7815e5490",
         "urls": [
-            "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/releases/download/v21.5/protoc-21.5-linux-ppcle_64.zip",
-            "https://github.com/protocolbuffers/protobuf/releases/download/v21.5/protoc-21.5-linux-ppcle_64.zip",
+            "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/releases/download/v21.7/protoc-21.7-linux-ppcle_64.zip",
+            "https://github.com/protocolbuffers/protobuf/releases/download/v21.7/protoc-21.7-linux-ppcle_64.zip",
         ],
     },
     "com_google_protobuf_protoc_linux_s390_64": {
         "build_file": "@rules_proto//proto/private:BUILD.protoc",
-        "sha256": "a80dadac9b4fa1e4db01a64423e36af5c336fb124dbfab15e8db7be86a611211",
+        "sha256": "983c1139e0e4ce6121028e0408919cd7a35a5c813f2df40066b05f822c1df226",
         "urls": [
-            "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/releases/download/v21.5/protoc-21.5-linux-s390_64.zip",
-            "https://github.com/protocolbuffers/protobuf/releases/download/v21.5/protoc-21.5-linux-s390_64.zip",
+            "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/releases/download/v21.7/protoc-21.7-linux-s390_64.zip",
+            "https://github.com/protocolbuffers/protobuf/releases/download/v21.7/protoc-21.7-linux-s390_64.zip",
         ],
     },
     "com_google_protobuf_protoc_linux_x86_32": {
         "build_file": "@rules_proto//proto/private:BUILD.protoc",
-        "sha256": "d5bf7641794e13e808c5b4a78facee1802fc2b9d5936c808440d213f1b6dcb84",
+        "sha256": "f245128a20586fc24dcd3f64a417313a228372fb37fe108d039b8927489b1b88",
         "urls": [
-            "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/releases/download/v21.5/protoc-21.5-linux-x86_32.zip",
-            "https://github.com/protocolbuffers/protobuf/releases/download/v21.5/protoc-21.5-linux-x86_32.zip",
+            "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/releases/download/v21.7/protoc-21.7-linux-x86_32.zip",
+            "https://github.com/protocolbuffers/protobuf/releases/download/v21.7/protoc-21.7-linux-x86_32.zip",
         ],
     },
     "com_google_protobuf_protoc_linux_x86_64": {
         "build_file": "@rules_proto//proto/private:BUILD.protoc",
-        "sha256": "92fb4f5066a6f7b870e09c73115a2c861852af8f6555d8da9955fdb80710bf7f",
+        "sha256": "0a260c6df439bcf1ecdd5e38e7a7648e4edf99c1a22a4cc66ce8e62c53bdb837",
         "urls": [
-            "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/releases/download/v21.5/protoc-21.5-linux-x86_64.zip",
-            "https://github.com/protocolbuffers/protobuf/releases/download/v21.5/protoc-21.5-linux-x86_64.zip",
+            "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/releases/download/v21.7/protoc-21.7-linux-x86_64.zip",
+            "https://github.com/protocolbuffers/protobuf/releases/download/v21.7/protoc-21.7-linux-x86_64.zip",
         ],
     },
     "com_google_protobuf_protoc_macos_aarch64": {
         "build_file": "@rules_proto//proto/private:BUILD.protoc",
-        "sha256": "b22aed8dce62656687c6c4a323aab4e6baf1cb81ee423e77bc671bd69679e2c3",
+        "sha256": "f79a67d708aba6ff2c6208578a6f2bf94f1528795aed646b65e99d4a678c97f8",
         "urls": [
-            "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/releases/download/v21.5/protoc-21.5-osx-aarch_64.zip",
-            "https://github.com/protocolbuffers/protobuf/releases/download/v21.5/protoc-21.5-osx-aarch_64.zip",
+            "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/releases/download/v21.7/protoc-21.7-osx-aarch_64.zip",
+            "https://github.com/protocolbuffers/protobuf/releases/download/v21.7/protoc-21.7-osx-aarch_64.zip",
         ],
     },
     "com_google_protobuf_protoc_macos_x86_64": {
         "build_file": "@rules_proto//proto/private:BUILD.protoc",
-        "sha256": "495d86aaaf5e8b536fbf04471ee9d7b21addeee5f1e949742c67bd09bb59c890",
+        "sha256": "cd3609fa1efc73db9c58fc63e40b240558eb2a8080b4fbfbe1c4b93bbedecc20",
         "urls": [
-            "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/releases/download/v21.5/protoc-21.5-osx-x86_64.zip",
-            "https://github.com/protocolbuffers/protobuf/releases/download/v21.5/protoc-21.5-osx-x86_64.zip",
+            "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/releases/download/v21.7/protoc-21.7-osx-x86_64.zip",
+            "https://github.com/protocolbuffers/protobuf/releases/download/v21.7/protoc-21.7-osx-x86_64.zip",
         ],
     },
     "com_google_protobuf_protoc_windows_x86_32": {
         "build_file": "@rules_proto//proto/private:BUILD.protoc",
-        "sha256": "aebf80fc77f1b7e6e3f46b737dffdc5fb8bcb8e75e89c8b56bf37c88aaa044ad",
+        "sha256": "1e3856cc5fc5074e566c7b8da90f74d2b5b6a80e3df9eafb4a86f7bb8ab32772",
         "urls": [
-            "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/releases/download/v21.5/protoc-21.5-win32.zip",
-            "https://github.com/protocolbuffers/protobuf/releases/download/v21.5/protoc-21.5-win32.zip",
+            "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/releases/download/v21.7/protoc-21.7-win32.zip",
+            "https://github.com/protocolbuffers/protobuf/releases/download/v21.7/protoc-21.7-win32.zip",
         ],
     },
     "com_google_protobuf_protoc_windows_x86_64": {
         "build_file": "@rules_proto//proto/private:BUILD.protoc",
-        "sha256": "1ecae2968d2f28364c3f43c55f687dd159568dc6b1b0dc7e1e93d99bccb896a6",
+        "sha256": "954cc5dfdb1d95d4c448c40f274d3720c018f73187b0c19b3c4f9bacc48d1ff0",
         "urls": [
-            "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/releases/download/v21.5/protoc-21.5-win64.zip",
-            "https://github.com/protocolbuffers/protobuf/releases/download/v21.5/protoc-21.5-win64.zip",
+            "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/releases/download/v21.7/protoc-21.7-win64.zip",
+            "https://github.com/protocolbuffers/protobuf/releases/download/v21.7/protoc-21.7-win64.zip",
         ],
     },
     # Dependency of `com_github_protocolbuffers_protobuf`.
@@ -151,42 +151,42 @@ dependencies = {
 
 maven_dependencies = {
     "com_google_protobuf_protobuf_java": {
-        "jar_sha256": "51febfb24af6faa7eb729c880b8ba011cbab8ce55920656a450740b73d343ee2",
+        "jar_sha256": "a204ec68748a7b26351ae37a311e8de468f248d1916d5f8dbe812c1289d0a0ff",
         "jar_urls": [
-            "https://mirror.bazel.build/repo1.maven.org/maven2/com/google/protobuf/protobuf-java/3.21.5/protobuf-java-3.21.5.jar",
-            "https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java/3.21.5/protobuf-java-3.21.5.jar",
+            "https://mirror.bazel.build/repo1.maven.org/maven2/com/google/protobuf/protobuf-java/3.21.7/protobuf-java-3.21.7.jar",
+            "https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java/3.21.7/protobuf-java-3.21.7.jar",
         ],
         "licenses": ["notice"],
-        "srcjar_sha256": "89a9038e7994b739cb86a37d22bc4e3feb4473fb041dfc9962263701d193debb",
+        "srcjar_sha256": "c664e12e6e3fea801477edf95014980a8a96528d3904d2add90c68b5d047a6c2",
         "srcjar_urls": [
-            "https://mirror.bazel.build/repo1.maven.org/maven2/com/google/protobuf/protobuf-java/3.21.5/protobuf-java-3.21.5-sources.jar",
-            "https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java/3.21.5/protobuf-java-3.21.5-sources.jar",
+            "https://mirror.bazel.build/repo1.maven.org/maven2/com/google/protobuf/protobuf-java/3.21.7/protobuf-java-3.21.7-sources.jar",
+            "https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java/3.21.7/protobuf-java-3.21.7-sources.jar",
         ],
     },
     "com_google_protobuf_protobuf_java_util": {
-        "jar_sha256": "34dc0c5bc98416e95a28b3b18caf74816eaa083b2f9c5702b2300a3763970c7b",
+        "jar_sha256": "9b98a2a4eb9ebc6103b14ab81badb82e32c8fe1d751aa4055830424974b7e142",
         "jar_urls": [
-            "https://mirror.bazel.build/repo1.maven.org/maven2/com/google/protobuf/protobuf-java-util/3.21.5/protobuf-java-util-3.21.5.jar",
-            "https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java-util/3.21.5/protobuf-java-util-3.21.5.jar",
+            "https://mirror.bazel.build/repo1.maven.org/maven2/com/google/protobuf/protobuf-java-util/3.21.7/protobuf-java-util-3.21.7.jar",
+            "https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java-util/3.21.7/protobuf-java-util-3.21.7.jar",
         ],
         "licenses": ["notice"],
-        "srcjar_sha256": "d186e9c3a86d1bdc40594b6373968f5f511a163af029c3dad9a91b9728c3b525",
+        "srcjar_sha256": "43b9188848b01cec71d34326868e25c102b2a344c6ef1072d54c3681559c5f57",
         "srcjar_urls": [
-            "https://mirror.bazel.build/repo1.maven.org/maven2/com/google/protobuf/protobuf-java-util/3.21.5/protobuf-java-util-3.21.5-sources.jar",
-            "https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java-util/3.21.5/protobuf-java-util-3.21.5-sources.jar",
+            "https://mirror.bazel.build/repo1.maven.org/maven2/com/google/protobuf/protobuf-java-util/3.21.7/protobuf-java-util-3.21.7-sources.jar",
+            "https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java-util/3.21.7/protobuf-java-util-3.21.7-sources.jar",
         ],
     },
     "com_google_protobuf_protobuf_javalite": {
-        "jar_sha256": "af39f44ff50d8f1ab4cc12b8a25d69638e7b42e6809c09073d8c02e32526993e",
+        "jar_sha256": "43945d791ece2012bb9086907e124ff814afd4014209f67cc89e7f324390c061",
         "jar_urls": [
-            "https://mirror.bazel.build/repo1.maven.org/maven2/com/google/protobuf/protobuf-javalite/3.21.5/protobuf-javalite-3.21.5.jar",
-            "https://repo1.maven.org/maven2/com/google/protobuf/protobuf-javalite/3.21.5/protobuf-javalite-3.21.5.jar",
+            "https://mirror.bazel.build/repo1.maven.org/maven2/com/google/protobuf/protobuf-javalite/3.21.7/protobuf-javalite-3.21.7.jar",
+            "https://repo1.maven.org/maven2/com/google/protobuf/protobuf-javalite/3.21.7/protobuf-javalite-3.21.7.jar",
         ],
         "licenses": ["notice"],
-        "srcjar_sha256": "184da632538ac0ede0bbf28ab014d193f4ca3e473979cd9ac4807a857e7bc089",
+        "srcjar_sha256": "e1c557e98c59d10dbd657c69a1e15b7585a592402f12c78026f9d0bfb605c310",
         "srcjar_urls": [
-            "https://mirror.bazel.build/repo1.maven.org/maven2/com/google/protobuf/protobuf-javalite/3.21.5/protobuf-javalite-3.21.5-sources.jar",
-            "https://repo1.maven.org/maven2/com/google/protobuf/protobuf-javalite/3.21.5/protobuf-javalite-3.21.5-sources.jar",
+            "https://mirror.bazel.build/repo1.maven.org/maven2/com/google/protobuf/protobuf-javalite/3.21.7/protobuf-javalite-3.21.7-sources.jar",
+            "https://repo1.maven.org/maven2/com/google/protobuf/protobuf-javalite/3.21.7/protobuf-javalite-3.21.7-sources.jar",
         ],
     },
 }


### PR DESCRIPTION
Updates protobuf version to 21.7 and fixes security issues mentioned in #148

Unfortunately not all mirror links are available for 21.7