### PR TITLE
Changing bazel skylib version from 1.1.1 to 1.3.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,7 +4,7 @@ module(
     version = "5.3.0-21.7",
 )
 
-bazel_dep(name = "bazel_skylib", version = "1.1.1")
+bazel_dep(name = "bazel_skylib", version = "1.3.0")
 bazel_dep(name = "protobuf", repo_name = "com_google_protobuf", version = "3.19.0")
 
 # TODO(bazel-team): add support for protobuf_workspace

--- a/proto/private/dependencies.bzl
+++ b/proto/private/dependencies.bzl
@@ -16,7 +16,7 @@
 
 dependencies = {
     "bazel_skylib": {
-        "sha256": "c6966ec828da198c5d9adbaa94c05e3a1c7f21bd012a0b29ba8ddbccb2c93b0d",
+        "sha256": "74d544d96f4a5bb630d465ca8bbcfe231e3594e5aae57e1edbf17a6eb3ca2506",
         "urls": [
             "https://github.com/bazelbuild/bazel-skylib/releases/download/1.3.0/bazel-skylib-1.3.0.tar.gz",
             "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.3.0/bazel-skylib-1.3.0.tar.gz",

--- a/proto/private/dependencies.bzl
+++ b/proto/private/dependencies.bzl
@@ -18,8 +18,8 @@ dependencies = {
     "bazel_skylib": {
         "sha256": "c6966ec828da198c5d9adbaa94c05e3a1c7f21bd012a0b29ba8ddbccb2c93b0d",
         "urls": [
-            "https://github.com/bazelbuild/bazel-skylib/releases/download/1.1.1/bazel-skylib-1.1.1.tar.gz",
-            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.1.1/bazel-skylib-1.1.1.tar.gz",
+            "https://github.com/bazelbuild/bazel-skylib/releases/download/1.3.0/bazel-skylib-1.3.0.tar.gz",
+            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.3.0/bazel-skylib-1.3.0.tar.gz",
         ],
     },
     "com_github_protocolbuffers_protobuf": {


### PR DESCRIPTION
This intends to be solving issue #10965 and #2530. It just updates bazel skylib to version 1.3.0.