### PR TITLE
Adds proto_api to redirected targets list

### DIFF
--- a/proto/private/BUILD.release
+++ b/proto/private/BUILD.release
@@ -80,6 +80,7 @@ redirect_targets = [
     "protoc_lib",
     "protobuf",
     "protobuf_lite",
+    "proto_api",
 ]
 
 [


### PR DESCRIPTION
This exposes the @com_google_protobuf//:protobuf_api target, which is a common dependency.

In particular, it is used by [pybind11_protobuf](https://github.com/pybind/pybind11_protobuf/blob/80f3440cd8fee124e077e2e47a8a17b78b451363/pybind11_protobuf/BUILD#L64), which I believe is also maintained by Google.

@laramiel, @rwgk FYI.