### PR TITLE
Suppress code generation for well-known types.

### DIFF
--- a/proto/private/BUILD.release
+++ b/proto/private/BUILD.release
@@ -42,6 +42,22 @@ proto_lang_toolchain(
     command_line = "--java_out=$(OUT)",
     runtime = ":protobuf_java",
     visibility = ["//visibility:public"],
+
+    # Keep in sync with @com_github_protocolbuffers_protobuf//:well_known_protos.
+    blacklisted_protos = [
+        "@com_google_protobuf//:any_proto",
+        "@com_google_protobuf//:api_proto",
+        "@com_google_protobuf//:compiler_plugin_proto",
+        "@com_google_protobuf//:descriptor_proto",
+        "@com_google_protobuf//:duration_proto",
+        "@com_google_protobuf//:empty_proto",
+        "@com_google_protobuf//:field_mask_proto",
+        "@com_google_protobuf//:source_context_proto",
+        "@com_google_protobuf//:struct_proto",
+        "@com_google_protobuf//:timestamp_proto",
+        "@com_google_protobuf//:type_proto",
+        "@com_google_protobuf//:wrappers_proto",
+    ],
 )
 
 proto_lang_toolchain(
@@ -49,6 +65,20 @@ proto_lang_toolchain(
     command_line = "--java_out=lite:$(OUT)",
     runtime = ":protobuf_javalite",
     visibility = ["//visibility:public"],
+
+    # Keep in sync with @com_github_protocolbuffers_protobuf//:lite_well_known_protos.
+    blacklisted_protos = [
+        "@com_google_protobuf//:any_proto",
+        "@com_google_protobuf//:api_proto",
+        "@com_google_protobuf//:duration_proto",
+        "@com_google_protobuf//:empty_proto",
+        "@com_google_protobuf//:field_mask_proto",
+        "@com_google_protobuf//:source_context_proto",
+        "@com_google_protobuf//:struct_proto",
+        "@com_google_protobuf//:timestamp_proto",
+        "@com_google_protobuf//:type_proto",
+        "@com_google_protobuf//:wrappers_proto",
+    ],
 )
 
 # Redirect everything else to the source


### PR DESCRIPTION
The runtime already supplies pre-compiled implementations for these.

Compiling the well-known types is always redundant work, but this duplication really becomes a problem when we resolve a proto runtime from Maven that's newer than the `protoc` used by `rules_proto`. When that happens, we get many compilation errors of the form

```
 error: name clash: clearExtension(GeneratedExtension<ExtensionRangeOptions,?>) in Builder and clearExtension(GeneratedExtension<ExtensionRangeOptions,T>) in ExtendableBuilder have the same erasure, yet neither overrides the other
      public <Type> Builder clearExtension(
                            ^
  where T,MessageT,BuilderT are type-variables:
    T extends Object declared in method <T>clearExtension(GeneratedExtension<MessageT,T>)
    MessageT extends ExtendableMessage<MessageT> declared in class ExtendableBuilder
    BuilderT extends ExtendableBuilder<MessageT,BuilderT> declared in class ExtendableBuilder
```

This particular error was produced by introducing
`build.buf:protovalidate:0.0.1` (depends on
`com.google.protobuf:protobuf-java:3.23.4`) to the Maven deps of a workspace that uses `rules_proto-4.0.0-3.20.0`, as exhibited by the repo contained in this
[gist](https://gist.github.com/plobsing/290f099fbc98e797013c990957f17f56) when using an unpatched `rules_proto`.

I had expected that using a protoc version of 3.20.0 and a runtime version of 3.23.4 should work based on the
[overall protobuf compatibility guarantee](https://protobuf.dev/support/cross-version-runtime-guarantee/) and the [java-specific statement](https://github.com/protocolbuffers/protobuf/blob/main/java/README.md#compatibility-notice). And, aside from this compilation issue, it does seem to.

This fix mirrors https://github.com/protocolbuffers/protobuf/pull/8942 made to the protobuf repo.