### PR TITLE
chore: introduce gazelle

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,15 @@
+load("@bazel_gazelle//:def.bzl", "gazelle", "gazelle_binary")
+
+gazelle_binary(
+    name = "gazelle_bin",
+    languages = [
+        "@bazel_skylib_gazelle_plugin//bzl",
+    ],
+)
+
+# gazelle:exclude tests/**
+# gazelle:exclude dev_deps.bzl
+gazelle(
+    name = "gazelle",
+    gazelle = "gazelle_bin",
+)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -12,3 +12,5 @@ bazel_dep(name = "protobuf", version = "21.7", repo_name = "com_google_protobuf"
 # Dependencies needed in tests
 bazel_dep(name = "rules_cc", version = "0.0.1", dev_dependency = True)
 bazel_dep(name = "googletest", version = "1.11.0", dev_dependency = True, repo_name = "com_google_googletest")
+bazel_dep(name = "gazelle", version = "0.29.0", dev_dependency = True, repo_name = "bazel_gazelle")
+bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.4.1", dev_dependency = True)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -6,26 +6,25 @@ rules_proto_dependencies()
 
 rules_proto_toolchains()
 
-# Test-only dependencies.
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+# Dev-only dependencies. USERS SHOULD NOT INSTALL THESE!
 
-http_archive(
-    name = "com_google_googletest",
-    sha256 = "81964fe578e9bd7c94dfdb09c8e4d6e6759e19967e397dbea48d1c10e45d0df2",
-    strip_prefix = "googletest-release-1.12.1",
-    urls = [
-        "https://mirror.bazel.build/github.com/google/googletest/archive/refs/tags/release-1.12.1.tar.gz",
-        "https://github.com/google/googletest/archive/refs/tags/release-1.12.1.tar.gz",
-    ],
-)
+load(":dev_deps.bzl", "rules_proto_dev_deps")
+rules_proto_dev_deps()
 
-http_archive(
-    name = "bazelci_rules",
-    sha256 = "eca21884e6f66a88c358e580fd67a6b148d30ab57b1680f62a96c00f9bc6a07e",
-    strip_prefix = "bazelci_rules-1.0.0",
-    url = "https://github.com/bazelbuild/continuous-integration/releases/download/rules-1.0.0/bazelci_rules-1.0.0.tar.gz",
-)
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+go_rules_dependencies()
+go_register_toolchains(version = "1.20.5")
+
+
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+gazelle_dependencies()
+
+load("@bazel_skylib_gazelle_plugin//:workspace.bzl", "bazel_skylib_gazelle_plugin_workspace")
+bazel_skylib_gazelle_plugin_workspace()
+
+load("@bazel_skylib_gazelle_plugin//:setup.bzl", "bazel_skylib_gazelle_plugin_setup")
+bazel_skylib_gazelle_plugin_setup(register_go_toolchains = False)
 
 load("@bazelci_rules//:rbe_repo.bzl", "rbe_preconfig")
 

--- a/dev_deps.bzl
+++ b/dev_deps.bzl
@@ -1,0 +1,53 @@
+"dev dependencies needed to develop rules_proto"
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+
+def rules_proto_dev_deps():
+    "declares dev dependency http archives"
+
+    http_archive(
+        name = "com_google_googletest",
+        sha256 = "81964fe578e9bd7c94dfdb09c8e4d6e6759e19967e397dbea48d1c10e45d0df2",
+        strip_prefix = "googletest-release-1.12.1",
+        urls = [
+            "https://mirror.bazel.build/github.com/google/googletest/archive/refs/tags/release-1.12.1.tar.gz",
+            "https://github.com/google/googletest/archive/refs/tags/release-1.12.1.tar.gz",
+        ],
+    )
+
+    http_archive(
+        name = "bazelci_rules",
+        sha256 = "eca21884e6f66a88c358e580fd67a6b148d30ab57b1680f62a96c00f9bc6a07e",
+        strip_prefix = "bazelci_rules-1.0.0",
+        urls = [
+            "https://github.com/bazelbuild/continuous-integration/releases/download/rules-1.0.0/bazelci_rules-1.0.0.tar.gz",
+        ],
+    )
+
+    http_archive(
+        name = "io_bazel_rules_go",
+        sha256 = "278b7ff5a826f3dc10f04feaf0b70d48b68748ccd512d7f98bf442077f043fe3",
+        urls = [
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.41.0/rules_go-v0.41.0.zip",
+            "https://github.com/bazelbuild/rules_go/releases/download/v0.41.0/rules_go-v0.41.0.zip",
+        ],
+    )
+
+    http_archive(
+        name = "bazel_gazelle",
+        sha256 = "d3fa66a39028e97d76f9e2db8f1b0c11c099e8e01bf363a923074784e451f809",
+        urls = [
+            "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.33.0/bazel-gazelle-v0.33.0.tar.gz",
+            "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.33.0/bazel-gazelle-v0.33.0.tar.gz",
+        ],
+    )
+    
+    http_archive(
+        name = "bazel_skylib_gazelle_plugin",
+        sha256 = "3327005dbc9e49cc39602fb46572525984f7119a9c6ffe5ed69fbe23db7c1560",
+        urls = [
+            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.4.2/bazel-skylib-gazelle-plugin-1.4.2.tar.gz",
+            "https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.2/bazel-skylib-gazelle-plugin-1.4.2.tar.gz",
+        ],
+    )

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -1,10 +1,14 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
+# Toolchain type provided by proto_toolchain rule and used by proto_library
+toolchain_type(
+    name = "toolchain_type",
+    visibility = ["//visibility:public"],
+)
+
 bzl_library(
     name = "defs",
-    srcs = [
-        "defs.bzl",
-    ],
+    srcs = ["defs.bzl"],
     visibility = ["//visibility:public"],
     deps = [
         "//proto/private:native",
@@ -13,29 +17,33 @@ bzl_library(
 )
 
 bzl_library(
-    name = "proto_toolchain_bzl",
-    srcs = [
-        "proto_toolchain.bzl",
-    ],
+    name = "repositories",
+    srcs = ["repositories.bzl"],
     visibility = ["//visibility:public"],
     deps = [
-        "//proto/private/rules:proto_toolchain_bzl",
+        "//proto/private:dependencies",
+        "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "@bazel_tools//tools/build_defs/repo:java.bzl",
+        "@bazel_tools//tools/build_defs/repo:utils.bzl",
     ],
 )
 
 bzl_library(
-    name = "repositories",
-    srcs = [
-        "repositories.bzl",
-    ],
+    name = "proto_common",
+    srcs = ["proto_common.bzl"],
     visibility = ["//visibility:public"],
-    deps = [
-        "//proto/private:dependencies",
-    ],
+    deps = ["//proto/private:native"],
 )
 
-# Toolchain type provided by proto_toolchain rule and used by proto_library
-toolchain_type(
-    name = "toolchain_type",
+bzl_library(
+    name = "proto_toolchain",
+    srcs = ["proto_toolchain.bzl"],
+    visibility = ["//visibility:public"],
+    deps = ["//proto/private/rules:proto_toolchain"],
+)
+
+bzl_library(
+    name = "proto_lang_toolchain",
+    srcs = ["proto_lang_toolchain.bzl"],
     visibility = ["//visibility:public"],
 )

--- a/proto/private/dependencies.bzl
+++ b/proto/private/dependencies.bzl
@@ -16,10 +16,10 @@
 
 dependencies = {
     "bazel_skylib": {
-        "sha256": "74d544d96f4a5bb630d465ca8bbcfe231e3594e5aae57e1edbf17a6eb3ca2506",
+        "sha256": "66ffd9315665bfaafc96b52278f57c7e2dd09f5ede279ea6d39b2be471e7e3aa",
         "urls": [
-            "https://github.com/bazelbuild/bazel-skylib/releases/download/1.3.0/bazel-skylib-1.3.0.tar.gz",
-            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.3.0/bazel-skylib-1.3.0.tar.gz",
+            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.4.2/bazel-skylib-1.4.2.tar.gz",
+            "https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.2/bazel-skylib-1.4.2.tar.gz",
         ],
     },
     "com_github_protocolbuffers_protobuf": {

--- a/proto/private/rules/BUILD
+++ b/proto/private/rules/BUILD
@@ -1,25 +1,22 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 bzl_library(
-    name = "proto_descriptor_set",
-    srcs = [
-        "proto_descriptor_set.bzl",
-    ],
-    visibility = [
-        "//proto:__subpackages__",
-    ],
-    deps = [
-        "//proto/private:native",
-    ],
+    name = "proto_toolchain",
+    srcs = ["proto_toolchain.bzl"],
+    visibility = ["//proto:__subpackages__"],
+    deps = [":proto_toolchain_rule"],
 )
 
 bzl_library(
-    name = "proto_toolchain_bzl",
-    srcs = [
-        "proto_toolchain.bzl",
-        "proto_toolchain_rule.bzl",
-    ],
-    visibility = [
-        "//proto:__subpackages__",
-    ],
+    name = "proto_toolchain_rule",
+    srcs = ["proto_toolchain_rule.bzl"],
+    visibility = ["//proto:__subpackages__"],
+    deps = ["//proto:proto_common"],
+)
+
+bzl_library(
+    name = "proto_descriptor_set",
+    srcs = ["proto_descriptor_set.bzl"],
+    visibility = ["//proto:__subpackages__"],
+    deps = ["//proto/private:native"],
 )

--- a/tests/load_from_macro/BUILD
+++ b/tests/load_from_macro/BUILD
@@ -1,5 +1,3 @@
-load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,9 +19,4 @@ proto_library(
     name = "foo",
     srcs = ["foo.proto"],
     tags = TAGS,
-)
-
-bzl_library(
-    name = "tags",
-    srcs = ["tags.bzl"],
 )


### PR DESCRIPTION
This introduces gazelle to allow us to generate bzl and proto targets automatically. We should also introduce a CI check to assert BUILD files are up to date.