### PR TITLE
chore: add a pre-commit hook config.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+# Optional local setup for a git pre-commit hook to automatically format/lint.
+# This avoids sending a red PR and having to find the buildifier output on the CI results page.
+# See https://pre-commit.com for more information on installing pre-commit.
+# See https://pre-commit.com/hooks.html for more hooks.
+
+repos:
+    # Check formatting and lint for starlark code
+    - repo: https://github.com/keith/pre-commit-buildifier
+      rev: 6.3.3
+      hooks:
+          - id: buildifier
+          - id: buildifier-lint


### PR DESCRIPTION
This matches the Bazel recommendation from https://github.com/bazel-contrib/rules-template for configuring an optional, client-side automation for formatting BUILD/bzl files before sending a PR.

It has been found to save a bunch of time for contributors who otherwise trip over the server-side CI check and have to do an extra iteration to get their PR green.

I imagine Googlers are already relying on some Piper feature to do the equivalent when they work on this code, so they haven't noticed the deficiency.