### PR TITLE
chore: add missing file needed by release automation

### DIFF
--- a/.github/workflows/ci.bazelrc
+++ b/.github/workflows/ci.bazelrc
@@ -1,0 +1,15 @@
+# This file contains Bazel settings to apply on CI only.
+# It is referenced with a --bazelrc option in the call to bazel in ci.yaml
+
+# Debug where options came from
+build --announce_rc
+# This directory is configured in GitHub actions to be persisted between runs.
+# We do not enable the repository cache to cache downloaded external artifacts
+# as these are generally faster to download again than to fetch them from the
+# GitHub actions cache.
+build --disk_cache=~/.cache/bazel
+# Don't rely on test logs being easily accessible from the test runner,
+# though it makes the log noisier.
+test --test_output=errors
+# Allows tests to run bazelisk-in-bazel, since this is the cache folder used
+test --test_env=XDG_CACHE_HOME


### PR DESCRIPTION
In https://github.com/bazel-contrib/.github/blob/master/.github/workflows/release_ruleset.yaml#L42 we assume this file will exist in the repo