### PR TITLE
chore: add config for Publish to BCR app

### DIFF
--- a/.bcr/config.yml
+++ b/.bcr/config.yml
@@ -1,0 +1,3 @@
+fixedReleaser:
+  login: alexeagle
+  email: alex@aspect.dev


### PR DESCRIPTION
Now that releases are automated, the release doesn't have an author, so the app can't figure out whose fork of bazel-central-registry the PR should originate from.

This will fix the error from publishing 6.0.0-rc0 to the BCR.