### PR TITLE
fix: presubmit does not have access to tests

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -5,4 +5,4 @@ tasks:
     name: "Verify build targets"
     platform: ${{ platform }}
     build_targets:
-      - "@rules_proto//..."
+      - "@rules_proto//proto/..."


### PR DESCRIPTION
This fixes the bcr presubmit. It was failing because the tests directory is excluded from the release archive.

See: https://github.com/bazelbuild/bazel-central-registry/pull/1174/commits/f4c8ec3d07ad5206d665171bc638b98f982b92c5