### PR TITLE
chore: expose toolchains helper as public API

### DIFF
--- a/docs/defs.md
+++ b/docs/defs.md
@@ -93,3 +93,59 @@ Toolchain target is suffixed with "_toolchain".
 | <a id="proto_toolchain-exec_compatible_with"></a>exec_compatible_with |  ([constraints]) List of constraints the prebuild binary is compatible with.   |  <code>[]</code> |
 
 
+<a id="toolchains.use_toolchain"></a>
+
+## toolchains.use_toolchain
+
+<pre>
+toolchains.use_toolchain(<a href="#toolchains.use_toolchain-toolchain_type">toolchain_type</a>)
+</pre>
+
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="toolchains.use_toolchain-toolchain_type"></a>toolchain_type |  <p align="center"> - </p>   |  none |
+
+
+<a id="toolchains.find_toolchain"></a>
+
+## toolchains.find_toolchain
+
+<pre>
+toolchains.find_toolchain(<a href="#toolchains.find_toolchain-ctx">ctx</a>, <a href="#toolchains.find_toolchain-legacy_attr">legacy_attr</a>, <a href="#toolchains.find_toolchain-toolchain_type">toolchain_type</a>)
+</pre>
+
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="toolchains.find_toolchain-ctx"></a>ctx |  <p align="center"> - </p>   |  none |
+| <a id="toolchains.find_toolchain-legacy_attr"></a>legacy_attr |  <p align="center"> - </p>   |  none |
+| <a id="toolchains.find_toolchain-toolchain_type"></a>toolchain_type |  <p align="center"> - </p>   |  none |
+
+
+<a id="toolchains.if_legacy_toolchain"></a>
+
+## toolchains.if_legacy_toolchain
+
+<pre>
+toolchains.if_legacy_toolchain(<a href="#toolchains.if_legacy_toolchain-legacy_attr_dict">legacy_attr_dict</a>)
+</pre>
+
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="toolchains.if_legacy_toolchain-legacy_attr_dict"></a>legacy_attr_dict |  <p align="center"> - </p>   |  none |
+
+

--- a/proto/defs.bzl
+++ b/proto/defs.bzl
@@ -16,7 +16,7 @@
 
 load("//proto:proto_descriptor_set.bzl", _proto_descriptor_set = "proto_descriptor_set")
 load("//proto:proto_library.bzl", _proto_library = "proto_library")
-load("//proto/modules:proto_common.bzl", _proto_common = "proto_common")
+load("//proto/modules:proto_common.bzl", _proto_common = "proto_common", _toolchains = "toolchains")
 load("//proto/modules:proto_info.bzl", _ProtoInfo = "ProtoInfo")
 load("//proto/toolchains:proto_lang_toolchain.bzl", _proto_lang_toolchain = "proto_lang_toolchain")
 load("//proto/toolchains:proto_toolchain.bzl", _proto_toolchain = "proto_toolchain")
@@ -32,3 +32,4 @@ proto_lang_toolchain = _proto_lang_toolchain
 # Modules
 proto_common = _proto_common
 ProtoInfo = _ProtoInfo
+toolchains = _toolchains

--- a/tests/proto_common/toolchains.bzl
+++ b/tests/proto_common/toolchains.bzl
@@ -14,9 +14,9 @@
 
 "unit tests for proto_common.toolchains"
 
-load("//proto/modules:proto_common.bzl", "toolchains")
 load("@bazel_skylib//lib:partial.bzl", "partial")
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load("//proto/modules:proto_common.bzl", "toolchains")
 
 def _test_toolchains_without_incompatible_flag(ctx):
     env = unittest.begin(ctx)


### PR DESCRIPTION
It's meant to be used in toolchainization of language rules, for example in rules_python: https://github.com/bazelbuild/rules_python/pull/1577/files#diff-9cb07a0e8453ad8b4f429bee2ccf9de818a78cfb6e5d9bb908d8518ea189e2a7R18

Fixes that PR following the recent breaking change landed here: https://github.com/bazelbuild/rules_proto/commit/d4c3498677e7fbda6f717585276ea4d8b75acec0#commitcomment-139420930