### PR TITLE
fix: rules_cc is not a dev_dependency

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,13 +7,14 @@ module(
     compatibility_level = 1,
 )
 
+# TODO(#203): remove dependency on compiling C++ tools
+bazel_dep(name = "rules_cc", version = "0.0.1")
 bazel_dep(name = "rules_license", version = "0.0.7")
 bazel_dep(name = "bazel_skylib", version = "1.3.0")
 bazel_dep(name = "bazel_features", version = "1.4.1")
 
 # Dependencies needed in tests
 bazel_dep(name = "stardoc", version = "0.5.6", dev_dependency = True, repo_name = "io_bazel_stardoc")
-bazel_dep(name = "rules_cc", version = "0.0.1", dev_dependency = True)
 bazel_dep(name = "googletest", version = "1.11.0", dev_dependency = True, repo_name = "com_google_googletest")
 bazel_dep(name = "protobuf", version = "23.1", dev_dependency = True, repo_name = "com_google_protobuf")
 bazel_dep(name = "platforms", version = "0.0.8", dev_dependency = True)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,6 @@ module(
     compatibility_level = 1,
 )
 
-# TODO(#203): remove dependency on compiling C++ tools
 bazel_dep(name = "rules_cc", version = "0.0.1")
 bazel_dep(name = "rules_license", version = "0.0.7")
 bazel_dep(name = "bazel_skylib", version = "1.3.0")


### PR DESCRIPTION
Since the tools/file_concat program is written in C++ and exposed to users of proto_descriptor_set, we depend on rules_cc at runtime.

Fixes #203