### PR TITLE
Update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,8 @@ on:
 
 jobs:
   release:
-    # Re-use https://github.com/bazel-contrib/.github/blob/v5/.github/workflows/release_ruleset.yaml
-    uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@v5
+    # Re-use https://github.com/bazel-contrib/.github/blob/v6/.github/workflows/release_ruleset.yaml
+    uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@v6
     with:
       prerelease: false
       release_files: rules_proto-*.tar.gz


### PR DESCRIPTION
The newer version uses https://github.com/bazel-contrib/setup-bazel which doesn't have a reference to XDG_CACHE_HOME.

Fixes https://github.com/bazel-contrib/.github/issues/16